### PR TITLE
Add guava dependency to work around conflict

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -33,4 +33,5 @@
 
   :dev-server
   {:extra-paths ["src/clj"]
-   :extra-deps {com.datomic/datomic-free {:mvn/version "0.9.5697"}}}}}
+   :extra-deps {com.datomic/datomic-free {:mvn/version "0.9.5697"}
+                com.google.guava/guava {:mvn/version "31.0.1-jre"}}}}}


### PR DESCRIPTION
Thomas Heller explains like so:

> my guess would be on a dependency conflict. I'm guessing that the presence of piggieback causes clojurescript to be added and loaded as well
> and clojurescript (or rather the closure-compiler) can fail to load with a conflicting guava dependency on the classpath
> which in turn comes from datomic
> dunno where that actual exception ends up though. it usually throws a proper exception making this easier to debug
> try adding this dep as well [com.google.guava/guava "31.0.1-jre"] via the alias or -Sdeps (edited) 
> confirms that its the dependency conflict if it works :wink:

See https://clojurians.slack.com/archives/C6QH853H8/p1663655723134009