### PR TITLE
Use re-frame for the create post form and errors

### DIFF
--- a/src/cljc/flybot/validation.cljc
+++ b/src/cljc/flybot/validation.cljc
@@ -28,6 +28,12 @@
   (let [validator (m/validator schema)]
     (if (validator data)
       data
-      (let [err (mu/explain-data schema data)]
-        (assoc data :post/error err)))))
+      (mu/explain-data schema data))))
+
+(defn error-msg
+  [errors]
+  (->> errors
+       :errors
+       (map #(select-keys % [:path :type]))
+       (str "FORM VALIDATION ERROR: ")))
 


### PR DESCRIPTION
Closes #53
---

- Use dispatch/subscribe of re-frame framework to manage the fields and errors related to the post creation.
- Provide better errors management for validation of for fields and server requests.