### PR TITLE
Use :with pattern option and improve components

### DIFF
--- a/resources/public/css/style.css
+++ b/resources/public/css/style.css
@@ -388,44 +388,45 @@ footer p {
 
 /* Page - all pages */
 
-section .page {
-    border-bottom-style: solid;
-    border-bottom-width: 1px;
-    border-bottom-color: var(--border-primary-color);
-}
-
-section .post-container {
+.page-header {
     padding: 2.5rem;
     border-bottom-style: solid;
     border-bottom-width: 1px;
     border-bottom-color: var(--border-primary-color);
 }
 
-section .post-container:nth-of-type(odd) {
+section .post {
+    padding: 2.5rem;
+    border-bottom-style: solid;
+    border-bottom-width: 1px;
+    border-bottom-color: var(--border-primary-color);
+}
+
+section .post:nth-of-type(odd) {
     background-color: var(--bg-secondary-color);
     border-right-width: 1px;
     border-right-color: var(--border-primary-color);
     border-right-style: solid;
 }
 
-section .post-container:nth-of-type(even) {
+section .post:nth-of-type(even) {
     background-color: var(--bg-primary-color);
     border-left-width: 1px;
     border-left-color: var(--border-primary-color);
     border-left-style: solid;
 }
 
-section .post-container .post-body {
+section .post .post-body {
     display: flex;
     justify-content: space-evenly;
     align-items: center;
 }
 
-section .post-container:nth-of-type(odd)>.post-body {
+section .post:nth-of-type(odd)>.post-body {
     flex-direction: row;
 }
 
-section .post-container:nth-of-type(even)>.post-body {
+section .post:nth-of-type(even)>.post-body {
     flex-direction: row-reverse;
 }
 
@@ -450,11 +451,11 @@ section .image>img {
 }
 
 @media (max-width: 1024px) {
-    section .post-container .post-body {
+    section .post .post-body {
         padding: 0.5rem;
         display: block;
     }
-    section .post-container .post-body>.image, section .post-body>.text {
+    section .post .post-body>.image, section .post-body>.text {
         width: 100%;
         margin: auto;
         padding: 1.5rem;
@@ -517,7 +518,7 @@ section.blog h1 {
 
 /* Post */
 
-.post-header, .page-header {
+.post-header{
     margin: 1rem;
 }
 

--- a/src/cljs/flybot/components/error.cljs
+++ b/src/cljs/flybot/components/error.cljs
@@ -1,0 +1,14 @@
+(ns cljs.flybot.components.error
+  (:require [re-frame.core :as rf]))
+
+(defn errors
+  [comp-id err-ids]
+  (when @(rf/subscribe [:subs.error/errors])
+    [:div.errors
+     {:key comp-id}
+     (doall
+      (for [id err-ids]
+        (when-let [error @(rf/subscribe [:subs.error/error id])]
+          [:div.error
+           {:key id}
+           error])))]))

--- a/src/cljs/flybot/components/page.cljs
+++ b/src/cljs/flybot/components/page.cljs
@@ -1,9 +1,12 @@
 (ns cljs.flybot.components.page
   (:require [cljs.flybot.lib.hiccup :as h]
             [cljs.flybot.components.post :as post]
+            [cljs.flybot.components.error :refer [errors]]
             [re-frame.core :as rf]))
 
-(defn post-container
+;;---------- Post ----------
+
+(defn render-post
   [post]
   (let [page-mode      @(rf/subscribe [:subs.page/mode])
         post-mode      @(rf/subscribe [:subs.post/mode])
@@ -13,14 +16,16 @@
           (post/post-read-only post)
           (= :edit page-mode)
           (post/post-read-only post)
-          (and (= :edit post-mode) (= edited-post-id (:post/id post)))
-          (post/post-edit edited-post-id)
-          (and (not= :read post-mode) (not= edited-post-id (:post/id post)) (not= {} post))
-          (post/post-read-only post)
           (and (= :create post-mode) (= {} post))
           (post/post-create "empty-post-id")
+          (and (= :edit post-mode) (= edited-post-id (:post/id post)))
+          (post/post-edit (or edited-post-id "problem"))
+          (and (not= :read post-mode) (not= edited-post-id (:post/id post)) (not= {} post))
+          (post/post-read-only post)
           :else
           (post/post-read post))))
+
+;;---------- Buttons ----------
 
 (defn edit-page-button
   []
@@ -38,43 +43,46 @@
    {:type "button"
     :value "Update Page"
     :on-change "ReadOnly"
-    :on-click #(rf/dispatch [:evt.page/send-page page-name])}])
+    :on-click #(rf/dispatch [:evt.page.form/send-page page-name])}])
 
-(defn page-form
+;;---------- From ----------
+
+(defn page-header-form
   [page-name]
-  [:div.page-body
-   [:form
-    [:fieldset
-     [:legend "Page Properties (Optional)"]
-     [:br]
-     [:label {:for "sorting-methods"} "Choose a sorting method:"]
-     [:br]
-     [:select#sorting-methods
-      {:name "Sorting Methods"
-       :on-change #(rf/dispatch [:evt.page/set-sorting-method
-                                 page-name
-                                 (.. % -target -value)])}
-      [:option {:value "{:sort/type :post/creation-date :sort/direction :ascending}"}
-       "Creation Date (Ascending)"]
-      [:option {:value "{:sort/type :post/creation-date :sort/direction :descending}"}
-       "Creation Date (Descending)"]
-      [:option {:value "{:sort/type :post/last-edit-date :sort/direction :ascending}"}
-       "Last Edit Date (Ascending)"]
-      [:option {:value "{:sort/type :post/last-edit-date :sort/direction :descending}"}
-       "Last Edit Date (Descending)"]]]]])
+  [:form
+   [:fieldset
+    [:legend "Page Properties (Optional)"]
+    [:br]
+    [:label {:for "sorting-methods"} "Choose a sorting method:"]
+    [:br]
+    [:select#sorting-methods
+     {:name "Sorting Methods"
+      :on-change #(rf/dispatch [:evt.page.form/set-sorting-method
+                                page-name
+                                (.. % -target -value)])}
+     [:option {:value "{:sort/type :post/creation-date :sort/direction :ascending}"}
+      "Creation Date (Ascending)"]
+     [:option {:value "{:sort/type :post/creation-date :sort/direction :descending}"}
+      "Creation Date (Descending)"]
+     [:option {:value "{:sort/type :post/last-edit-date :sort/direction :ascending}"}
+      "Last Edit Date (Ascending)"]
+     [:option {:value "{:sort/type :post/last-edit-date :sort/direction :descending}"}
+      "Last Edit Date (Descending)"]]]])
 
-(defn page-config
+(defn page-header
   [page-name]
   (when (= :editor @(rf/subscribe [:subs.user/mode]))
-    [:div.page
+    [:div.page-header
      {:key (or page-name (str "config-of" page-name))}
-     [:div.page-header
-      [:form
-       [edit-page-button]
-       (when (= :edit @(rf/subscribe [:subs.page/mode]))
-         [submit-page-button page-name])]]
-     (when (= :edit @(rf/subscribe [:subs.page/mode]))
-       [page-form page-name])]))
+     (if (= :edit @(rf/subscribe [:subs.page/mode]))
+       [:<>
+        [errors page-name [:validation-errors :failure-http-result]]
+        [:form
+         [edit-page-button]
+         [submit-page-button page-name]]
+        [page-header-form page-name]]
+       [:form
+        [edit-page-button]])]))
 
 (defn sort-posts
   [{:sort/keys [type direction]} posts]
@@ -85,7 +93,7 @@
 (defn page
   "Given the `page-name`, returns the page content."
   [page-name]
-  (let [sorting-method @(rf/subscribe [:subs.page/sorting-method page-name])
+  (let [sorting-method @(rf/subscribe [:subs.page.form/sorting-method page-name])
         ordered-posts (->> @(rf/subscribe [:subs.post/posts page-name])
                            (map h/add-hiccup)
                            (sort-posts sorting-method))
@@ -94,12 +102,10 @@
                               (= :read @(rf/subscribe [:subs.page/mode])))
                        (conj ordered-posts empty-post)
                        ordered-posts)]
-    [:<>
-     [:section.container
-      [page-config page-name]]
-     [:section.container
-      {:class (name page-name)
-       :key   (name page-name)}
-      (-> (for [post posts]
-            (post-container post))
-          doall)]]))
+    [:section.container
+     {:class (name page-name)
+      :key   (name page-name)}
+     [page-header page-name]
+     (doall
+      (for [post posts]
+        (render-post post)))]))

--- a/src/cljs/flybot/components/page.cljs
+++ b/src/cljs/flybot/components/page.cljs
@@ -18,8 +18,8 @@
           (post/post-read-only post)
           (and (= :create post-mode) (= {} post))
           (post/post-create "empty-post-id")
-          (and (= :edit post-mode) (= edited-post-id (:post/id post)))
-          (post/post-edit (or edited-post-id "problem"))
+          (and (= :edit post-mode) (= edited-post-id (:post/id post)) (not= {} post))
+          (post/post-edit edited-post-id)
           (and (not= :read post-mode) (not= edited-post-id (:post/id post)) (not= {} post))
           (post/post-read-only post)
           :else


### PR DESCRIPTION
Closes #72
---
- Use pattern with `:with` option
- Add reusable `errors` component
- Improve component naming for better clarity