### PR TITLE
Page mode and post mode scope adjusted

### DIFF
--- a/src/cljc/flybot/utils.cljc
+++ b/src/cljc/flybot/utils.cljc
@@ -1,0 +1,13 @@
+(ns cljc.flybot.utils)
+
+(defn temporary-id?
+  [id]
+  (= "new-post-temp-id" id))
+
+(defn to-indexed-maps
+  "Transforms a vector of maps `v` to a map of maps using the given key `k` as index.
+   i.e: [{:a :a1 :b :b1} {:a :a2 :b :b2}]
+   => {:a1 {:a :a1 :b :b1} :a2 {:a :a2 :b :b2}}"
+  [k v]
+  (into {} (map (juxt k identity) v)))
+

--- a/src/cljc/flybot/validation.cljc
+++ b/src/cljc/flybot/validation.cljc
@@ -1,5 +1,6 @@
 (ns cljc.flybot.validation
-  (:require [malli.core :as m]
+  (:require [cljc.flybot.utils :as utils]
+            [malli.core :as m]
             [malli.util :as mu]))
 
 ;;---------- Schemas ----------
@@ -65,22 +66,20 @@
 
 #?(:cljs
    (defn prepare-post
-     "Given the `fields` of a post,
-      returns a post map matching server format requirements."
-     [fields]
-     (if (= "new-post-temp-id" (:post/id fields))
-       (-> fields
+     "Given a `post` from the post form,
+      returns a post matching server format requirements."
+     [post]
+     (let [temp-id?   (-> post :post/id utils/temporary-id?)
+           date-field (if temp-id? :post/creation-date :post/last-edit-date)]
+       (-> post
            (dissoc :post/view :post/mode)
-           (assoc :post/id (random-uuid)
-                  :post/creation-date (js/Date.)))
-       (-> fields
-           (dissoc :post/view :post/mode)
-           (assoc :post/last-edit-date (js/Date.))))))
+           (update :post/id (if temp-id? random-uuid identity))
+           (assoc date-field (js/Date.))))))
 
 #?(:cljs
    (defn prepare-page
-     "Given the `fields` of a page,
-      returns a page map matching server format requirements."
-     [fields]
-     (dissoc fields :page/mode)))
+     "Given the `page` from the page form,
+      returns a page matching server format requirements."
+     [page]
+     (dissoc page :page/mode)))
 

--- a/src/cljc/flybot/validation.cljc
+++ b/src/cljc/flybot/validation.cljc
@@ -65,16 +65,22 @@
 
 #?(:cljs
    (defn prepare-post
-     "Given the `fields` of a post form and the current `page-name`,
+     "Given the `fields` of a post,
       returns a post map matching server format requirements."
-     [fields page-name]
-     (if (:post/id fields)
+     [fields]
+     (if (= "new-post-temp-id" (:post/id fields))
        (-> fields
-           (dissoc :post/view)
-           (assoc :post/last-edit-date (js/Date.)))
-       (-> fields
-           (dissoc :post/view)
+           (dissoc :post/view :post/mode)
            (assoc :post/id (random-uuid)
-                  :post/page page-name
-                  :post/creation-date (js/Date.))))))
+                  :post/creation-date (js/Date.)))
+       (-> fields
+           (dissoc :post/view :post/mode)
+           (assoc :post/last-edit-date (js/Date.))))))
+
+#?(:cljs
+   (defn prepare-page
+     "Given the `fields` of a page,
+      returns a page map matching server format requirements."
+     [fields]
+     (dissoc fields :page/mode)))
 

--- a/src/cljs/flybot/components/post.cljs
+++ b/src/cljs/flybot/components/post.cljs
@@ -10,7 +10,7 @@
   []
   [:input.button
    {:type "button"
-    :value (if (= :preview @(rf/subscribe [:subs.form/field :post/view]))
+    :value (if (= :preview @(rf/subscribe [:subs.post.form/field :post/view]))
              "Edit Post"
              "Preview Post")
     :on-change "ReadOnly"
@@ -28,21 +28,13 @@
   [post-id]
   [:input.button
    {:type "button"
-    :value (if (= :edit @(rf/subscribe [:subs.post/mode]))
+    :value (if (= :edit @(rf/subscribe [:subs.post/mode post-id]))
              "Cancel"
-             "Edit Post")
+             (if (= post-id "new-post-temp-id")
+               "Create Post"
+               "Edit Post"))
     :on-change "ReadOnly"
     :on-click #(rf/dispatch [:evt.post/toggle-edit-mode post-id])}])
-
-(defn create-button
-  []
-  [:input.button
-   {:type "button"
-    :value (if (= :create @(rf/subscribe [:subs.post/mode]))
-             "Cancel"
-             "Create Post")
-    :on-change "ReadOnly"
-    :on-click #(rf/dispatch [:evt.post/toggle-create-mode])}])
 
 (defn delete-button
   [post-id]
@@ -67,7 +59,7 @@
       {:type "text"
        :name "css-class"
        :placeholder "my-post-1"
-       :value @(rf/subscribe [:subs.form/field :post/css-class])
+       :value @(rf/subscribe [:subs.post.form/field :post/css-class])
        :on-change #(rf/dispatch [:evt.post.form/set-field
                                  :post/css-class
                                  (.. % -target -value)])}]
@@ -78,8 +70,8 @@
       {:type "url"
        :name "img-src"
        :placeholder "https://my.image.com/photo-1"
-       :value @(rf/subscribe [:subs.image/field :image/src])
-       :on-change #(rf/dispatch [:evt.image/set-field
+       :value @(rf/subscribe [:subs.form.image/field :image/src])
+       :on-change #(rf/dispatch [:evt.form.image/set-field
                                  :image/src
                                  (.. % -target -value)])}]
      [:br]
@@ -89,8 +81,8 @@
       {:type "url"
        :name "img-src-dark"
        :placeholder "https://my.image.com/photo-1"
-       :value @(rf/subscribe [:subs.image/field :image/src-dark])
-       :on-change #(rf/dispatch [:evt.image/set-field
+       :value @(rf/subscribe [:subs.form.image/field :image/src-dark])
+       :on-change #(rf/dispatch [:evt.form.image/set-field
                                  :image/src-dark
                                  (.. % -target -value)])}]
      [:br]
@@ -100,8 +92,8 @@
       {:type "text"
        :name "img-alt"
        :placeholder "Coffee on table"
-       :value @(rf/subscribe [:subs.image/field :image/alt])
-       :on-change #(rf/dispatch [:evt.image/set-field
+       :value @(rf/subscribe [:subs.form.image/field :image/alt])
+       :on-change #(rf/dispatch [:evt.form.image/set-field
                                  :image/alt
                                  (.. % -target -value)])}]
      [:br]
@@ -110,7 +102,7 @@
      [:input
       {:type "checkbox"
        :name "show-dates"
-       :default-checked (when @(rf/subscribe [:subs.form/field :post/show-dates?]) "checked")
+       :default-checked (when @(rf/subscribe [:subs.post.form/field :post/show-dates?]) "checked")
        :on-click #(rf/dispatch [:evt.post.form/set-field
                                 :post/show-dates?
                                 (.. % -target -checked)])}]
@@ -126,7 +118,7 @@
       {:name "md-content"
        :required "required"
        :placeholder "# My Post Title\n\n## Part 1\n\nSome content of part 1\n..."
-       :value @(rf/subscribe [:subs.form/field :post/md-content])
+       :value @(rf/subscribe [:subs.post.form/field :post/md-content])
        :on-change #(rf/dispatch [:evt.post.form/set-field
                                  :post/md-content
                                  (.. % -target -value)])}]]]])
@@ -168,10 +160,11 @@
   [{:post/keys [id]
     :or {id "empty-read-only-id"}
     :as post}]
-  [:div.post
-   {:key id
-    :id id}
-   [post-view post]])
+  (when-not (= "new-post-temp-id" id)
+    [:div.post
+     {:key id
+      :id id}
+     [post-view post]]))
 
 (defn post-read
   "Post with a button to create/edit."
@@ -182,31 +175,12 @@
    {:key id
     :id id}
    [:div.post-header
-    (if (= "empty-read-id" id) 
-      [:form
-       [create-button id]]
-      [:form
-       [edit-button id]
-       [delete-button id]])]
-   (when id
-     [post-view post])])
-
-(defn post-create
-  "Create Post Form with preview feature."
-  [post-id]
-  [:div.post
-   {:key post-id
-    :id  post-id}
-   [:div.post-header
     [:form
-     [preview-button]
-     [submit-button]
-     [create-button post-id]]
-    [errors post-id [:validation-errors :failure-http-result]]]
-   (if (= :preview @(rf/subscribe [:subs.form/field :post/view]))
-     [post-view
-      (h/add-hiccup @(rf/subscribe [:subs.form/fields]))]
-     [post-form post-id])])
+     [edit-button id]
+     (when-not (= "new-post-temp-id" id)
+       [delete-button id])]]
+   (when-not (= "new-post-temp-id" id)
+     [post-view post])])
 
 (defn post-edit
   "Edit Post Form with preview feature."
@@ -218,10 +192,10 @@
     [:form
      [preview-button]
      [submit-button]
-     [edit-button]
+     [edit-button post-id]
      [delete-button post-id]]
     [errors post-id [:validation-errors :failure-http-result]]]
-   (if (= :preview @(rf/subscribe [:subs.form/field :post/view]))
+   (if (= :preview @(rf/subscribe [:subs.post.form/field :post/view]))
      [post-view
-      (h/add-hiccup @(rf/subscribe [:subs.form/fields]))]
+      (h/add-hiccup @(rf/subscribe [:subs.post.form/fields]))]
      [post-form])])

--- a/src/cljs/flybot/components/post.cljs
+++ b/src/cljs/flybot/components/post.cljs
@@ -1,5 +1,6 @@
 (ns cljs.flybot.components.post
-  (:require [cljs.flybot.lib.hiccup :as h]
+  (:require [cljc.flybot.utils :as utils]
+            [cljs.flybot.lib.hiccup :as h]
             [cljs.flybot.components.header :refer [theme-logo]]
             [cljs.flybot.components.error :refer [errors]]
             [re-frame.core :as rf]))
@@ -160,7 +161,7 @@
   [{:post/keys [id]
     :or {id "empty-read-only-id"}
     :as post}]
-  (when-not (= "new-post-temp-id" id)
+  (when-not (utils/temporary-id? id)
     [:div.post
      {:key id
       :id id}
@@ -177,9 +178,9 @@
    [:div.post-header
     [:form
      [edit-button id]
-     (when-not (= "new-post-temp-id" id)
+     (when-not (utils/temporary-id? id)
        [delete-button id])]]
-   (when-not (= "new-post-temp-id" id)
+   (when-not (utils/temporary-id? id)
      [post-view post])])
 
 (defn post-edit


### PR DESCRIPTION
Closes #74
---
[Frontend]
- Each post as its `:post/mode` (:read or :edit)
- Each page as its `:page/mode` (:read or :edit)
- Pages and Posts data structure are now indexed by `:page/name` and `:post/id`
- Post logic is now the same for a new post or existing post
- Some refactoring were done thanks to the above improvements