### PR TITLE
78 api tests

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -24,7 +24,7 @@
 
            ;; work around to resolve the dep conflict introduced by datomic
            com.google.guava/guava                {:mvn/version "31.0.1-jre"}}
- :paths   ["dev/src" "src" "src/clj" "src/cljc" "test" "test/clj" "test/cljs" "src/cljs" "target" "resources"]
+ :paths   ["dev/src" "src" "src/clj" "src/cljc" "test" "test/clj" "test/cljs" "test/cljc" "src/cljs" "target" "resources"]
  :aliases
  {:dev
   {:main-opts ["--main"  "figwheel.main"

--- a/dev.cljs.edn
+++ b/dev.cljs.edn
@@ -1,4 +1,4 @@
-^{:watch-dirs ["src/cljs" "src/cljc" "test/cljs"]
+^{:watch-dirs ["src/cljs" "src/cljc" "test/cljs" "test/cljc"]
   :css-dirs   ["resources/public/css"]}
 {:main cljs.flybot.core
  :optimizations :none}

--- a/src/clj/flybot/handler.clj
+++ b/src/clj/flybot/handler.clj
@@ -4,7 +4,6 @@
             [cljc.flybot.validation :as v]
             [datomic.api :as d]
             [muuntaja.core :as m]
-            [reitit.middleware :as middleware]
             [reitit.ring :as reitit]
             [reitit.ring.middleware.muuntaja :as muuntaja]
             [sg.flybot.pullable :as pull]))
@@ -36,20 +35,23 @@
           resp    (pull/run pattern
                             v/api-schema
                             (op/pullable-data (first executors) db))]
-      {:body    (first resp)
-       :headers {"content-type" "application/edn"}})))
+      (if (:error resp)
+        (throw (ex-info "invalid pattern" (merge {:type :pattern} resp)))
+        {:body    (first resp)
+         :headers {"content-type" "application/edn"}}))))
 
 (defn app-routes
   "API routes, returns a ring-handler."
   [ring-handler]
   (reitit/ring-handler
    (reitit/router
-    [["/all" {:post ring-handler :middleware [:content :wrap-base]}]
+    [["/all" {:post ring-handler}]
      ["/*"   (reitit/create-resource-handler {:root "public"})]]
     {:conflicts            (constantly nil)
-     ::middleware/registry {:content muuntaja/format-middleware
-                            :wrap-base mw/wrap-base}
-     :data                 {:muuntaja m/instance}})
+     :data                 {:muuntaja m/instance
+                            :middleware [muuntaja/format-middleware
+                                         mw/wrap-base
+                                         mw/exception-middleware]}})
    (reitit/create-default-handler
     {:not-found          (constantly {:status 404, :body "Page not found"})
      :method-not-allowed (constantly {:status 405, :body "Not allowed"})

--- a/src/clj/flybot/handler.clj
+++ b/src/clj/flybot/handler.clj
@@ -53,6 +53,6 @@
                                          mw/wrap-base
                                          mw/exception-middleware]}})
    (reitit/create-default-handler
-    {:not-found          (constantly {:status 404, :body "Page not found"})
-     :method-not-allowed (constantly {:status 405, :body "Not allowed"})
-     :not-acceptable     (constantly {:status 406, :body "Not acceptable"})})))
+    {:not-found          (constantly {:status 404 :body "Page not found"})
+     :method-not-allowed (constantly {:status 405 :body "Not allowed"})
+     :not-acceptable     (constantly {:status 406 :body "Not acceptable"})})))

--- a/src/clj/flybot/middleware.clj
+++ b/src/clj/flybot/middleware.clj
@@ -1,6 +1,24 @@
 (ns clj.flybot.middleware
   (:require
-   [ring.middleware.defaults :refer [site-defaults wrap-defaults]]))
+   [ring.middleware.defaults :refer [site-defaults wrap-defaults]]
+   [reitit.ring.middleware.exception :as exception]))
+
+(defn handler [status message exception request]
+  {:status status
+   :headers {"content-type" "application/edn"}
+   :body {:message message
+          :data (ex-data exception)
+          :uri (:uri request)}})
+
+(def exception-middleware
+  (exception/create-exception-middleware
+   (merge
+    exception/default-handlers
+    {;; ex-data with :type :pattern
+     :pattern (partial handler 502 "invalid pattern provided")
+
+       ;; override the default handler
+     ::exception/default (partial handler 500 "default")})))
 
 (defn wrap-base
   [handler]

--- a/src/clj/flybot/middleware.clj
+++ b/src/clj/flybot/middleware.clj
@@ -12,13 +12,10 @@
 
 (def exception-middleware
   (exception/create-exception-middleware
-   (merge
-    exception/default-handlers
-    {;; ex-data with :type :pattern
-     :pattern (partial handler 502 "invalid pattern provided")
-
-       ;; override the default handler
-     ::exception/default (partial handler 500 "default")})))
+   {;; ex-data with :type :pattern
+    :pattern (partial handler 407 "invalid pattern provided")
+    ;; override the default handler
+    ::exception/default (partial handler 500 "default")}))
 
 (defn wrap-base
   [handler]

--- a/src/cljc/flybot/validation.cljc
+++ b/src/cljc/flybot/validation.cljc
@@ -31,7 +31,7 @@
      [:sort/direction :keyword]]]])
 
 (def api-schema
-  [:map
+  [:map {:closed true}
    [:posts
     {:optional true}
     [:map

--- a/test/clj/flybot/handler_test.clj
+++ b/test/clj/flybot/handler_test.clj
@@ -1,9 +1,44 @@
 (ns clj.flybot.handler-test
-  (:require [clj.flybot.db :as db]
+  (:require [aleph.http :as http]
+            [clj-commons.byte-streams :as bs]
+            [clj.flybot.db :as db]
             [clj.flybot.handler :as sut]
-            [clojure.test :refer [use-fixtures deftest is testing]]
+            [clojure.test :refer [deftest is testing use-fixtures]]
             [datomic.api :as d]
-            [robertluo.fun-map :refer [closeable fnk life-cycle-map touch halt!]]))
+            [robertluo.fun-map :refer [closeable fnk halt! life-cycle-map touch]]
+            [clojure.edn :as edn]))
+
+;;---------- Sample data ----------
+
+(def post-1-id (d/squuid))
+(def post-2-id (d/squuid))
+(def post-3-id (d/squuid))
+(def post-1-create-date (java.util.Date.))
+(def post-2-create-date (java.util.Date.))
+(def post-1 {:post/id post-1-id
+             :post/page :home
+             :post/css-class "post-1"
+             :post/creation-date post-1-create-date
+             :post/md-content "#Some content 1"
+             :post/image-beside {:image/src "https://some-image.svg"
+                                 :image/src-dark "https://some-image-dark-mode.svg"
+                                 :image/alt "something"}})
+(def post-2 {:post/id post-2-id
+             :post/page :home
+             :post/css-class "post-2"
+             :post/creation-date post-2-create-date
+             :post/md-content "#Some content 2"})
+
+(def home-page {:page/name           :home
+                :page/sorting-method {:sort/type :post/creation-date
+                                      :sort/direction :ascending}})
+(def apply-page {:page/name :apply})
+
+(defn sample-data->db
+  [conn]
+  @(d/transact conn [post-1 post-2 home-page apply-page]))
+
+;;---------- System ----------
 
 (def test-system
   (life-cycle-map
@@ -12,7 +47,7 @@
                         (d/create-database db-uri)
                         (let [conn (d/connect db-uri)]
                           (db/add-schemas conn)
-                          (db/add-initial-data conn)
+                          (sample-data->db conn)
                           (closeable
                            conn
                            #(d/delete-database db-uri))))
@@ -23,14 +58,24 @@
     :ring-handler  (fnk [injectors executors]
                         (sut/mk-ring-handler injectors executors))
     :reitit-router (fnk [ring-handler]
-                        (sut/app-routes ring-handler))}))
+                        (sut/app-routes ring-handler))
+    :http-port     8100
+    :http-server   (fnk [http-port reitit-router]
+                        (let [svr (http/start-server
+                                   reitit-router
+                                   {:port http-port})]
+                          (closeable
+                           svr
+                           #(.close svr))))}))
 
-(defn my-test-fixture [f]
+(defn system-fixture [f]
   (touch test-system)
   (f)
   (halt! test-system))
 
-(use-fixtures :once my-test-fixture)
+(use-fixtures :once system-fixture)
+
+;;---------- Tests ----------
 
 (deftest executor
   (let [executor (-> test-system :executors first)]
@@ -49,15 +94,108 @@
                                                   [response ::EFFECTS-RESPONSE])}}}))))))
 
 (deftest ring-handler
-  (testing "Returns the proper ring response"
+  (testing "Returns the proper ring response."
     (let [ring-handler (:ring-handler test-system)]
-      (is (= [#:page{:name :home} #:page{:name :apply} #:page{:name :about} #:page{:name :blog}]
-             (-> (ring-handler {:body-params {:pages
-                                              {(list :all :with [])
-                                               [{:page/name '?}]}}})
+      (is (= apply-page
+             (-> {:body-params
+                  {:pages
+                   {(list :page :with [:apply])
+                    {:page/name '?}}}}
+                 ring-handler
                  :body
                  :pages
-                 :all))))))
+                 :page))))))
 
-;; TODO: test for app routes
+(defn post-request
+  [uri body]
+  (-> @(http/request
+        {:content-type :edn
+         :accept       :edn
+         :url          (str "http://localhost:8100" uri)
+         :method       :post
+         :body         (str body)})
+      :body
+      bs/to-string
+      edn/read-string))
+
+(deftest app-routes
+  ;;---------- Errors
+  (testing "Invalid pattern so returns error."
+    (let [resp (post-request "/all"
+                             {:pages
+                              {(list :all :with [])
+                               [{:invalid-key '?}]}})]
+      ;; TOFIX: should catch pattern error via mw/esception-middleware and return
+      ;; the pattern error with 502 status
+      ;; Current behaviour: throw the error 502 but do not catch it.
+      (is (= "Invalid client pattern data"
+             (-> resp :error :cause)))))
+
+  ;;---------- Pages 
+  (testing "Execute a request for all pages."
+    (let [resp (post-request "/all"
+                             {:pages
+                              {(list :all :with [])
+                               [{:page/name '?}]}})]
+      (is (= [{:page/name :home} {:page/name :apply}]
+             (-> resp :pages :all)))))
+  (testing "Execute a request for a page."
+    (let [resp (post-request "/all"
+                             {:pages
+                              {(list :page :with [:home])
+                               {:page/name '?}}})]
+      (is (= {:page/name :home}
+             (-> resp :pages :page)))))
+  (testing "Execute a request for a new page."
+    (let [resp (post-request "/all"
+                             {:pages
+                              {(list :new-page :with [{:page/name :about}])
+                               {:page/name '?}}})]
+      (is (= {:page/name :about}
+             (-> resp :pages :new-page)))))
+  
+  ;;---------- Posts
+  (testing "Execute a request for all posts."
+    (let [resp (post-request "/all"
+                             {:posts
+                              {(list :all :with [])
+                               [{:post/id '?
+                                 :post/page '?
+                                 :post/creation-date '?
+                                 :post/md-content '?}]}})]
+      (is (= [post-1-id post-2-id]
+             (->> resp :posts :all (map :post/id))))))
+  (testing "Execute a request for a post."
+    (let [resp (post-request "/all"
+                             {:posts
+                              {(list :post :with [post-1-id])
+                               {:post/id '?
+                                :post/page '?
+                                :post/creation-date '?
+                                :post/md-content '?}}})]
+      (is (= post-1-id
+             (-> resp :posts :post :post/id)))))
+  (testing "Execute a request for a new post."
+    (let [resp (post-request "/all"
+                             {:posts
+                              {(list :new-post :with [{:post/id            post-3-id
+                                                       :post/page          :home
+                                                       :post/creation-date (java.util.Date.)
+                                                       :post/md-content    "Content"}])
+                               {:post/id '?
+                                :post/page '?
+                                :post/creation-date '?
+                                :post/md-content '?}}})]
+      (is (= post-3-id
+             (->> resp :posts :new-post :post/id)))))
+  (testing "Execute a request for a delete post."
+    (let [resp (post-request "/all"
+                             {:posts
+                              {(list :removed-post :with [post-3-id])
+                               {:post/id '?
+                                :post/page '?
+                                :post/creation-date '?
+                                :post/md-content '?}}})]
+      (is (= post-3-id
+             (-> resp :posts :removed-post :post/id))))))
 

--- a/test/cljc/flybot/sample_data.cljc
+++ b/test/cljc/flybot/sample_data.cljc
@@ -1,0 +1,42 @@
+(ns cljc.flybot.sample-data
+  "Sample data that can be used in both backend and frontend tests."
+  (:require #?(:clj [datomic.api :as d])))
+
+(defn mk-uuid
+  []
+  #?(:clj (d/squuid) :cljs (random-uuid)))
+
+(defn mk-date
+  []
+  #?(:clj (java.util.Date.) :cljs (js/Date.)))
+
+(def post-1-id (mk-uuid))
+(def post-2-id (mk-uuid))
+(def post-3-id (mk-uuid))
+(def post-1-create-date (mk-date))
+(def post-2-create-date (mk-date))
+(def post-1 {:post/id post-1-id
+             :post/page :home
+             :post/css-class "post-1"
+             :post/creation-date post-1-create-date
+             :post/md-content "#Some content 1"
+             :post/image-beside {:image/src "https://some-image.svg"
+                                 :image/src-dark "https://some-image-dark-mode.svg"
+                                 :image/alt "something"}})
+(def post-2 {:post/id post-2-id
+             :post/page :home
+             :post/css-class "post-2"
+             :post/creation-date post-2-create-date
+             :post/md-content "#Some content 2"})
+
+(def home-page {:page/name           :home
+                :page/sorting-method {:sort/type :post/creation-date
+                                      :sort/direction :ascending}})
+(def apply-page {:page/name :apply})
+
+(def init-pages-and-posts
+  {:posts {:all [post-1 post-2]}
+   :pages {:all [{:page/name :home
+                  :page/sorting-method {:sort/type :post/creation-date
+                                        :sort/direction :ascending}}
+                 {:page/name :apply}]}})


### PR DESCRIPTION
Closes #78
---
- Add the backend api routes tests using some sample data and a test `system`
- Add error handling for the pattern
- Move the sample data to a `.cljc` ns so both backend and front-end can access it conveniently