### PR TITLE
Use advanced pull query

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -15,7 +15,7 @@
            metosin/reitit                        {:mvn/version "0.5.18"}
            metosin/muuntaja                      {:mvn/version "0.6.8"}
            flybot-sg/lasagna-pull                {:git/url "https://github.com/flybot-sg/lasagna-pull.git"
-                                                  :sha     "f94bb4b8f8ee1450f7b50d8c9473489a46d5868e"}
+                                                  :sha     "ed0258e6293e972ba2c886939cef59c4ebbd7f89"}
 
            ;; back-end
            aleph/aleph                           {:mvn/version "0.5.0"}

--- a/src/clj/flybot/core.clj
+++ b/src/clj/flybot/core.clj
@@ -22,7 +22,7 @@
     :injectors     (fnk [db-conn]
                         [(fn [] {:db (d/db db-conn)})])
     :executors     (fnk [db-conn]
-                        [(handler/mk-executor db-conn)])
+                        [(handler/mk-executors db-conn)])
     :ring-handler  (fnk [injectors executors]
                         (handler/mk-ring-handler injectors executors))
     :reitit-router (fnk [ring-handler]

--- a/src/clj/flybot/core.clj
+++ b/src/clj/flybot/core.clj
@@ -10,31 +10,32 @@
 
 (def system
   (life-cycle-map
-   {:db-uri        "datomic:mem://website"
-    :db-conn       (fnk [db-uri]
-                        (d/create-database db-uri)
-                        (let [conn (d/connect db-uri)]
-                          (db/add-schemas conn)
-                          (db/add-initial-data conn)
-                          (closeable
-                           conn
-                           #(d/delete-database db-uri))))
-    :injectors     (fnk [db-conn]
-                        [(fn [] {:db (d/db db-conn)})])
-    :executors     (fnk [db-conn]
-                        [(handler/mk-executors db-conn)])
-    :ring-handler  (fnk [injectors executors]
-                        (handler/mk-ring-handler injectors executors))
-    :reitit-router (fnk [ring-handler]
-                        (handler/app-routes ring-handler))
-    :http-port     8123
-    :http-server   (fnk [http-port reitit-router]
-                        (let [svr (http/start-server
-                                   reitit-router
-                                   {:port http-port})]
-                          (closeable
-                           svr
-                           #(.close svr))))}))
+   {:db-uri         "datomic:mem://website"
+    :db-conn        (fnk [db-uri]
+                         (d/create-database db-uri)
+                         (let [conn (d/connect db-uri)]
+                           (db/add-schemas conn)
+                           (db/add-initial-data conn)
+                           (closeable
+                            conn
+                            #(d/delete-database db-uri))))
+    :injectors      (fnk [db-conn]
+                         [(fn [] {:db (d/db db-conn)})])
+    :executors      (fnk [db-conn]
+                         [(handler/mk-executors db-conn)])
+    :saturn-handler handler/saturn-handler
+    :ring-handler   (fnk [injectors saturn-handler executors]
+                         (handler/mk-ring-handler injectors saturn-handler executors))
+    :reitit-router  (fnk [ring-handler]
+                         (handler/app-routes ring-handler))
+    :http-port      8123
+    :http-server    (fnk [http-port reitit-router]
+                         (let [svr (http/start-server
+                                    reitit-router
+                                    {:port http-port})]
+                           (closeable
+                            svr
+                            #(.close svr))))}))
 
 (defn -main [& _]
   (touch system))

--- a/src/clj/flybot/operation.clj
+++ b/src/clj/flybot/operation.clj
@@ -42,11 +42,11 @@
   "Path to be pulled with the pull-pattern.
    The pull-pattern `:with` option will provide the params to execute the function
    before pulling it."
-  [executor db]
-  {:posts {:all          (fn [] (executor (get-all-posts db)))
-           :post         (fn [post-id] (executor (get-post db post-id)))
-           :new-post     (fn [post] (executor (add-post post)))
-           :removed-post (fn [post-id] (executor (delete-post post-id)))}
-   :pages {:all          (fn [] (executor (get-all-pages db)))
-           :page         (fn [page-name] (executor (get-page db page-name)))
-           :new-page     (fn [page] (executor (add-page page)))}})
+  [db]
+  {:posts {:all          (fn [] (get-all-posts db))
+           :post         (fn [post-id] (get-post db post-id))
+           :new-post     (fn [post] (add-post post))
+           :removed-post (fn [post-id] (delete-post post-id))}
+   :pages {:all          (fn [] (get-all-pages db))
+           :page         (fn [page-name] (get-page db page-name))
+           :new-page     (fn [page] (add-page page))}})

--- a/src/cljc/flybot/validation.cljc
+++ b/src/cljc/flybot/validation.cljc
@@ -92,7 +92,7 @@
         date-field (if temp-id? :post/creation-date :post/last-edit-date)]
     (-> post
         (dissoc :post/view :post/mode)
-        (update :post/id (if temp-id? (u/mk-uuid) identity))
+        (update :post/id (if temp-id? #(u/mk-uuid) identity))
         (assoc date-field (u/mk-date)))))
 
 (defn prepare-page

--- a/test/clj/flybot/handler_test.clj
+++ b/test/clj/flybot/handler_test.clj
@@ -17,31 +17,32 @@
 
 (def test-system
   (life-cycle-map
-   {:db-uri        "datomic:mem://website-test"
-    :db-conn       (fnk [db-uri]
-                        (d/create-database db-uri)
-                        (let [conn (d/connect db-uri)]
-                          (db/add-schemas conn)
-                          (sample-data->db conn)
-                          (closeable
-                           conn
-                           #(d/delete-database db-uri))))
-    :injectors     (fnk [db-conn]
-                        [(fn [] {:db (d/db db-conn)})])
-    :executors     (fnk [db-conn]
-                        [(sut/mk-executors db-conn)])
-    :ring-handler  (fnk [injectors executors]
-                        (sut/mk-ring-handler injectors executors))
-    :reitit-router (fnk [ring-handler]
-                        (sut/app-routes ring-handler))
-    :http-port     8100
-    :http-server   (fnk [http-port reitit-router]
-                        (let [svr (http/start-server
-                                   reitit-router
-                                   {:port http-port})]
-                          (closeable
-                           svr
-                           #(.close svr))))}))
+   {:db-uri         "datomic:mem://website-test"
+    :db-conn        (fnk [db-uri]
+                         (d/create-database db-uri)
+                         (let [conn (d/connect db-uri)]
+                           (db/add-schemas conn)
+                           (sample-data->db conn)
+                           (closeable
+                            conn
+                            #(d/delete-database db-uri))))
+    :injectors      (fnk [db-conn]
+                         [(fn [] {:db (d/db db-conn)})])
+    :executors      (fnk [db-conn]
+                         [(sut/mk-executors db-conn)])
+    :saturn-handler sut/saturn-handler
+    :ring-handler   (fnk [injectors saturn-handler executors]
+                         (sut/mk-ring-handler injectors saturn-handler executors))
+    :reitit-router  (fnk [ring-handler]
+                         (sut/app-routes ring-handler))
+    :http-port      8100
+    :http-server    (fnk [http-port reitit-router]
+                         (let [svr (http/start-server
+                                    reitit-router
+                                    {:port http-port})]
+                           (closeable
+                            svr
+                            #(.close svr))))}))
 
 (defn system-fixture [f]
   (touch test-system)
@@ -79,6 +80,22 @@
           q       (sut/mk-query pattern)]
       (is (= [{:a ::RESP-A :b ::RESP-B} {:all-effects [::EFFECTS-A ::EFFECTS-B]}]
              (q data))))))
+
+(deftest saturn-handler
+  (testing "Returns the proper saturn response."
+    (let [saturn-handler (:saturn-handler test-system)
+          db-conn        (:db-conn test-system)]
+      (is (= {:response     {:posts
+                             {:removed-post
+                              #:post{:id ::ID}}}
+              :effects-desc [{:db
+                              {:payload
+                               [[:db/retractEntity
+                                 [:post/id ::ID]]]}}]}
+             (saturn-handler {:body-params {:posts
+                                            {(list :removed-post :with [::ID])
+                                             {:post/id '?}}}
+                              :db (d/db db-conn)}))))))
 
 (deftest ring-handler
   (testing "Returns the proper ring response."

--- a/test/cljc/flybot/sample_data.cljc
+++ b/test/cljc/flybot/sample_data.cljc
@@ -2,13 +2,12 @@
   "Sample data that can be used in both backend and frontend tests."
   (:require [cljc.flybot.utils :as u]))
 
-
-
 (def post-1-id (u/mk-uuid))
 (def post-2-id (u/mk-uuid))
 (def post-3-id (u/mk-uuid))
 (def post-1-create-date (u/mk-date))
 (def post-2-create-date (u/mk-date))
+(def post-3-create-date (u/mk-date))
 (def post-1 {:post/id post-1-id
              :post/page :home
              :post/css-class "post-1"
@@ -24,7 +23,7 @@
              :post/md-content "#Some content 2"})
 (def post-3 {:post/id            post-3-id
              :post/page          :home
-             :post/creation-date (java.util.Date.)
+             :post/creation-date post-3-create-date
              :post/md-content    "Content"})
 
 (def home-page {:page/name           :home


### PR DESCRIPTION
Closes #71
---

- Use advanced query to gather effects in one vector
- Execute all effects in one executor after the pull is done
- Fix interop error in cljc
- Re-introduce pure saturn-handler