### PR TITLE
Add external config and session to systems

### DIFF
--- a/config/system.edn
+++ b/config/system.edn
@@ -1,0 +1,10 @@
+{:prod     {:http-port       8123
+            :db-uri          "datomic:mem://website"
+            :oauth2-callback "http://localhost:8123/oauth/google/callback"}
+ :dev      {:http-port       8123
+            :db-uri          "datomic:mem://website-dev"
+            :oauth2-callback "http://localhost:8123/oauth/google/callback"}
+ :figwheel {:db-uri          "datomic:mem://website-figwheel"
+            :oauth2-callback "http://localhost:9500/oauth/google/callback"}
+ :test     {:http-port       8100
+            :db-uri          "datomic:mem://website-test"}}

--- a/dev/src/clj/flybot/figwheel.clj
+++ b/dev/src/clj/flybot/figwheel.clj
@@ -1,21 +1,18 @@
 (ns clj.flybot.figwheel
   (:require [clj.flybot.core :as core]
-            [robertluo.fun-map :refer [touch halt!]]))
+            [robertluo.fun-map :refer [touch]]))
 
 ;;---------- System for front-end dev ----------
+;; Figwheel automatically start the system for us via the figwheel-main.edn
+;; If some changes are made in one of the component (such as handler for instance),
+;; just reload this namespace and refresh your browser.
 
 (def figwheel-system
-  (-> core/system
-      (dissoc :http-port :http-server)
-      (assoc-in [:oauth2-config :google :redirect-uri] "http://localhost:9500/oauth/google/callback")))
-
+  (-> (core/system-config :figwheel)
+      core/system
+      (dissoc :http-port :http-server)))
 
 (def figwheel-handler
   (-> figwheel-system
       touch
       :reitit-router))
-
-(comment
-  (touch figwheel-system)
-  (halt! figwheel-system)
-  )

--- a/src/clj/flybot/core.clj
+++ b/src/clj/flybot/core.clj
@@ -1,17 +1,19 @@
 (ns clj.flybot.core
   (:require [aleph.http :as http]
-            [robertluo.fun-map :refer [fnk life-cycle-map closeable touch halt!]]
             [clj.flybot.handler :as handler]
-            [clojure.edn :as edn]
             [clj.flybot.db :as db]
-            [datomic.api :as d])
+            [clojure.edn :as edn]
+            [datomic.api :as d]
+            [ring.middleware.session.memory :refer [memory-store]]
+            [robertluo.fun-map :refer [fnk life-cycle-map closeable touch halt!]])
   (:gen-class))
 
 ;;---------- System ----------
 
-(def system
+(defn system
+  [{:keys [http-port db-uri oauth2-callback]}]
   (life-cycle-map
-   {:db-uri         "datomic:mem://website"
+   {:db-uri         db-uri
     :db-conn        (fnk [db-uri]
                          (d/create-database db-uri)
                          (let [conn (d/connect db-uri)]
@@ -20,7 +22,10 @@
                            (closeable
                             conn
                             #(d/delete-database db-uri))))
-    :oauth2-config  (edn/read-string (slurp "config/google-creds.edn"))
+    :oauth2-config  (assoc-in (edn/read-string (slurp "config/google-creds.edn"))
+                              [:google :redirect-uri]
+                              oauth2-callback)
+    :session-store  (memory-store)
     :injectors      (fnk [db-conn]
                          [(fn [] {:db (d/db db-conn)})])
     :executors      (fnk [db-conn]
@@ -28,9 +33,9 @@
     :saturn-handler handler/saturn-handler
     :ring-handler   (fnk [injectors saturn-handler executors]
                          (handler/mk-ring-handler injectors saturn-handler executors))
-    :reitit-router  (fnk [ring-handler oauth2-config]
-                         (handler/app-routes ring-handler oauth2-config))
-    :http-port      8123
+    :reitit-router  (fnk [ring-handler oauth2-config session-store]
+                         (handler/app-routes ring-handler oauth2-config session-store))
+    :http-port      http-port
     :http-server    (fnk [http-port reitit-router]
                          (let [svr (http/start-server
                                     reitit-router
@@ -39,10 +44,20 @@
                             svr
                             #(.close svr))))}))
 
+(defn system-config
+  [env]
+  (-> (slurp "config/system.edn") edn/read-string env))
+
+(def dev-system
+  (system (system-config :dev)))
+
+(def prod-system
+  (system (system-config :prod)))
+
 (defn -main [& _]
-  (touch system))
+  (touch prod-system))
 
 (comment
-  (touch system)
-  (halt! system)
+  (touch dev-system)
+  (halt! dev-system)
   )

--- a/src/clj/flybot/handler.clj
+++ b/src/clj/flybot/handler.clj
@@ -99,7 +99,7 @@
 
 (defn app-routes
   "API routes, returns a ring-handler."
-  [ring-handler oauth2-config]
+  [ring-handler oauth2-config session-store]
   (reitit/ring-handler
    (reitit/router
     (into (auth/auth-routes oauth2-config)
@@ -129,9 +129,8 @@
            ["/*"   (reitit/create-resource-handler {:root "public"})]])
     {:conflicts (constantly nil)
      :data      {:muuntaja   m/instance
-                 :middleware [mw/wrap-session-custom
-                              muuntaja/format-middleware
-                              mw/wrap-defaults-custom
+                 :middleware [muuntaja/format-middleware
+                              [mw/wrap-defaults-custom session-store]
                               mw/exception-middleware]}})
    (reitit/create-default-handler
     {:not-found          (constantly {:status 404 :body "Page not found"})

--- a/src/clj/flybot/middleware.clj
+++ b/src/clj/flybot/middleware.clj
@@ -1,11 +1,6 @@
 (ns clj.flybot.middleware
   (:require [reitit.ring.middleware.exception :as exception]
-            [ring.middleware.defaults :refer [site-defaults wrap-defaults]]
-            [ring.middleware.session :refer [wrap-session]]
-            [ring.middleware.session.memory :refer [memory-store]]))
-
-(def session-store
-  (memory-store))
+            [ring.middleware.defaults :refer [site-defaults wrap-defaults]]))
 
 (defn handler [status message exception request]
   {:status status
@@ -25,18 +20,15 @@
     :authorization         (partial handler 413 "User does not have the required permission.")
     ::exception/default    (partial handler 500 "Default")}))
 
-(def ring-config
+(defn ring-cfg
+  [session-store]
   (-> site-defaults
       (assoc-in [:security :anti-forgery] false)
       (assoc-in [:session :store] session-store)
       (assoc-in [:session :cookie-attrs :same-site] :lax)))
 
 (defn wrap-defaults-custom
-  [handler]
+  [handler session-store]
   (-> handler
       (wrap-defaults
-       ring-config)))
-
-(defn wrap-session-custom
-  [handler]
-  (wrap-session handler (:session ring-config)))
+       (ring-cfg session-store))))

--- a/src/clj/flybot/operation.clj
+++ b/src/clj/flybot/operation.clj
@@ -55,13 +55,14 @@
              :user-id user-id}}))
 
 (defn register-user
-  [db id email name picture]
-  (if-let [user (db/get-user db id)]
+  [db user-id email name picture]
+  (if-let [{:user/keys [id roles] :as user} (db/get-user db user-id)]
     ;; already in db so just return user
     {:response user
-     :session  {:user-id id}}
+     :session  {:user-id    id
+                :user-roles (map :role/name roles)}}
     ;; first login so add to db
-    (let [user #:user{:id      id
+    (let [user #:user{:id      user-id
                       :email   email
                       :name    name
                       :picture picture
@@ -69,7 +70,7 @@
                                        :date-granted (utils/mk-date)}]}]
       {:response user
        :effects  {:db {:payload [user]}}
-       :session  {:user-id id}})))
+       :session  {:user-id user-id}})))
 
 (defn delete-user
   [db id]


### PR DESCRIPTION
Closes #87
---

- Reuse same default system for dev, prod, figwheel and testing.
- Slurp external config (port, db-uri, oauth2) to create different env systems.
- Add session store to the system