### PR TITLE
Move jvm-opts to alias and use latest datalevin

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -21,7 +21,7 @@
   [_]
   (println "[START] -> Client : Generate js bundle")
   (clean nil)
-  (b/process {:command-args ["clojure" "-M:fig:prod"]})
+  (b/process {:command-args ["clojure" "-M:jvm-base:fig:prod"]})
   (move-js nil)
   (clean nil)
   (println "[END] -> Client : Generate js bundle"))
@@ -31,7 +31,7 @@
 (def lib 'flybot.sg)
 (def version (format "1.2.%s" (b/git-count-revs nil)))
 (def class-dir "target/classes")
-(def basis (b/create-basis {:project "deps.edn"}))
+(def basis (b/create-basis {:project "deps.edn" :aliases [:jvm-base]}))
 (def uber-file (format "target/%s-%s-standalone.jar" (name lib) version))
 
 (defn uber
@@ -56,11 +56,3 @@
 (defn deploy [_]
   (deploy-client nil)
   (uber nil))
-
-;; run the jar:
-;; SYSTEM="SYSTEM" OAUTH2="OAUTH2" java -jar target/flybot.sg-1.2.110-standalone.jar
-
-
-
-
-

--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,5 @@
 {:deps    {;; both frontend and backend
+           org.clojure/clojure                   {:mvn/version "1.11.1"}
            metosin/malli                         {:mvn/version "0.8.9"}
            metosin/reitit                        {:mvn/version "0.5.18"}
            metosin/muuntaja                      {:mvn/version "0.6.8"}
@@ -9,15 +10,15 @@
            ring/ring-defaults                    {:mvn/version "0.3.4"}
            aleph/aleph                           {:mvn/version "0.5.0"}
            robertluo/fun-map                     {:mvn/version "0.5.109"}
-           datalevin/datalevin                   {:mvn/version "0.6.22"}
+           datalevin/datalevin                   {:mvn/version "0.7.6"}
            skydread1/reitit-oauth2               {:git/url "https://github.com/skydread1/reitit-oauth2.git"
                                                   :sha     "c06a3be2f00d5358a50c108816fe0cbfa9f67be1"}}
  :paths   ["src" "resources"]
- ;; must be added to run datalevin with java11
- :jvm-opts ["--add-opens=java.base/java.nio=ALL-UNNAMED"
-            "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"]
  :aliases
  {;;---------- BACKEND (clj) aliases ----------
+  ;; JVM options to make datalevin work with java version > java8
+  :jvm-base {:jvm-opts ["--add-opens=java.base/java.nio=ALL-UNNAMED"
+                        "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"]}
   ;; CLJ paths for the backend tests
   :test {:extra-paths ["test" "dev/src" "config" "target"]}
   

--- a/jib-dev.edn
+++ b/jib-dev.edn
@@ -1,10 +1,13 @@
 ;; Image config to test de containerised app locally.
 ;; defalut base image for this is gcr.io/distroless/java.
-{:main clj.flybot.core
+{:main         clj.flybot.core
+ :aliases      [:jvm-base]
  ;; to be provided at container start via -e for instance.
- :env-vars      {:SYSTEM "SYSTEM"
-                 :OAUTH2 "OAUTH2"}
+ :env-vars     {:SYSTEM "SYSTEM"
+                :OAUTH2 "OAUTH2"}
  :user          "root"
  :group         "root"
+ :base-image   {:image-name "openjdk:11-slim-buster"
+                :type       :registry}
  :target-image {:image-name "flybot/image"
-                :type :docker}}
+                :type       :docker}}

--- a/jib.edn
+++ b/jib.edn
@@ -1,10 +1,13 @@
 ;; Image config to create the image and push it to ECR
 {:main           clj.flybot.core
+ :aliases        [:jvm-base]
  ;; to be provided at container start via -e for instance.
  :env-vars      {:SYSTEM "SYSTEM"
                  :OAUTH2 "OAUTH2"}
  :user          "root"
  :group         "root"
+ :base-image   {:image-name "openjdk:11-slim-buster"
+                :type       :registry}
  :target-image {:image-name "688541077069.dkr.ecr.ap-southeast-1.amazonaws.com/flybot-website"
                 :type       :registry
                 :tagger     {:fn jibbit.tagger/tag} ;; can comment to push images with unclean git dir for testing


### PR DESCRIPTION
Closes #94
---

- Update `datalevin` to latest version to access Apple Silicon support.
- Move `jvm-opts` to dedicated alias to be able to use  datalevin with latest java version
- Use a more complete base image with `jibbit`

New image was pushed on AWS ECR and new docker container was launch from it on the EC2.