### PR TITLE
Add author and last-editor to UI

### DIFF
--- a/resources/public/css/style.css
+++ b/resources/public/css/style.css
@@ -296,12 +296,6 @@ header .top {
     align-items: center;
 }
 
-@media (max-width: 1024px) {
-    header .top>* {
-        width: 20%;
-    }
-}
-
 .pointer {
     cursor: pointer;
 }

--- a/resources/public/css/style.css
+++ b/resources/public/css/style.css
@@ -259,6 +259,11 @@ input[type=button] {
     height: 32px;
 }
 
+.post-icon {
+    width: 22px;
+    height: 22px;
+}
+
 .burger {
     fill: var(--text-primary-color);
     width: 32px;
@@ -403,11 +408,31 @@ footer p {
     border-bottom-color: var(--border-primary-color);
 }
 
+@media (max-width: 1024px) {
+    section .page-header {
+        padding: 0.5rem;
+    }
+}
+
+@media (max-width: 1024px) {
+    .page-header>form {
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
+    }
+}
+
 section .post {
     padding: 2.5rem;
     border-bottom-style: solid;
     border-bottom-width: 1px;
     border-bottom-color: var(--border-primary-color);
+}
+
+@media (max-width: 1024px) {
+    section .post {
+        padding: 0.5rem;
+    }
 }
 
 section .post:nth-of-type(odd) {
@@ -442,6 +467,12 @@ section .post-body>div {
     padding: 1.5rem;
 }
 
+@media (max-width: 1024px) {
+    section .post-body>div {
+        padding: 0.5rem;
+    }
+}
+
 section .post-body>.image {
     width: 25%;
 }
@@ -466,7 +497,7 @@ section .image>img {
     section .post .post-body>.image, section .post-body>.text {
         width: 100%;
         margin: auto;
-        padding: 1.5rem;
+        padding: 0.5rem;
     }
 }
 
@@ -485,6 +516,13 @@ section .button  {
     border-width: 2px;
     border-color: var(--border-primary-color);
     background-color: var(--button-primary-color);
+}
+
+@media (max-width: 1024px) {
+    section .button  {
+        width: 50%;
+        margin: 0.5rem auto;
+    }
 }
 
 /* Apply page */
@@ -526,19 +564,39 @@ section.blog h1 {
 
 /* Post */
 
-.post-header{
-    margin: 1rem;
+@media (max-width: 1024px) {
+    .post-header>form {
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
+    }
 }
 
-.post-header .button, .page-header .button {
-    min-width: 30%;
-    padding: 0.5rem;
+@media (min-width: 1024px) {
+    .post-header {
+        margin: 1rem;
+    }
 }
 
-.post-dates {
-    font-size: 0.8rem;
+.post-authors {
     border-bottom: groove;
     border-bottom-width: thin;
+}
+
+.post-author {
+    display: flex;
+    align-items: center;
+    font-size: 0.8rem;
+}
+
+@media (max-width: 1024px) {
+    .post-author {
+        font-size: 0.7rem;
+    }
+}
+
+.post-author>div {
+    padding: 0.3rem;
 }
 
 @media (min-width: 1024px) {

--- a/src/cljs/flybot/db.cljs
+++ b/src/cljs/flybot/db.cljs
@@ -54,8 +54,11 @@
 (rf/reg-event-fx
  :fx.http/post-success
  (fn [{:keys [db]} [_ {:keys [posts]}]]
-   (let [post (:post posts)]
-     {:db (assoc db :form/fields post)
+   (let [post        (:post posts)
+         last-editor (or (:post/last-editor post) (:app/user db))]
+     {:db (assoc db :form/fields (assoc post
+                                        :post/last-editor last-editor
+                                        :post/last-edit-date (js/Date.)))
       :fx [[:fx.log/message ["Got the post " (:post/id post)]]]})))
 
 (rf/reg-event-fx
@@ -135,8 +138,10 @@
                                :post/css-class '?
                                :post/creation-date '?
                                :post/last-edit-date '?
-                               :post/author {:user/id '?}
-                               :post/last-editor {:user/id '?}
+                               :post/author {:user/id '?
+                                             :user/name '?}
+                               :post/last-editor {:user/id '?
+                                                  :user/name '?}
                                :post/show-authors? '?
                                :post/show-dates? '?
                                :post/md-content '?
@@ -394,8 +399,10 @@
                                          :post/css-class '?
                                          :post/creation-date '?
                                          :post/last-edit-date '?
-                                         :post/author {:user/id '?}
-                                         :post/last-editor {:user/id '?}
+                                         :post/author {:user/id '?
+                                                       :user/name '?}
+                                         :post/last-editor {:user/id '?
+                                                            :user/name '?}
                                          :post/show-authors? '?
                                          :post/show-dates? '?
                                          :post/md-content '?
@@ -416,7 +423,9 @@
      {:db         (assoc db :form/fields
                          {:post/id   post-id
                           :post/page (-> db :app/current-view :data :page-name)
-                          :post/mode :edit})}
+                          :post/mode :edit
+                          :post/author (-> db :app/user (select-keys [:user/id :user/name]))
+                          :post/creation-date (js/Date.)})}
      {:http-xhrio {:method          :post
                    :uri             "/posts/post"
                    :params          {:posts
@@ -426,8 +435,10 @@
                                        :post/css-class '?
                                        :post/creation-date '?
                                        :post/last-edit-date '?
-                                       :post/author {:user/id '?}
-                                       :post/last-editor {:user/id '?}
+                                       :post/author {:user/id '?
+                                                     :user/name '?}
+                                       :post/last-editor {:user/id '?
+                                                          :user/name '?}
                                        :post/show-authors? '?
                                        :post/show-dates? '?
                                        :post/md-content '?

--- a/src/cljs/flybot/db.cljs
+++ b/src/cljs/flybot/db.cljs
@@ -58,7 +58,7 @@
          last-editor (or (:post/last-editor post) (:app/user db))]
      {:db (assoc db :form/fields (assoc post
                                         :post/last-editor last-editor
-                                        :post/last-edit-date (js/Date.)))
+                                        :post/last-edit-date (utils/mk-date)))
       :fx [[:fx.log/message ["Got the post " (:post/id post)]]]})))
 
 (rf/reg-event-fx
@@ -425,7 +425,7 @@
                           :post/page (-> db :app/current-view :data :page-name)
                           :post/mode :edit
                           :post/author (-> db :app/user (select-keys [:user/id :user/name]))
-                          :post/creation-date (js/Date.)})}
+                          :post/creation-date (utils/mk-date)})}
      {:http-xhrio {:method          :post
                    :uri             "/posts/post"
                    :params          {:posts


### PR DESCRIPTION
Closes #86 
---

## Scope: front-end

- [x] Add `author` and `last-editor` to the posts.
- [x] Add an flag `show-authors?` in the post forms to add/remove the authors (don't need authors for home page for example)
- [x] Add simple css (see screenshot below)
- [x] Add front test to validate author/editor front-end logic

## Web

![Screenshot 2022-12-30 at 3 11 36 PM](https://user-images.githubusercontent.com/16139969/210044197-2ff65b1d-1872-4f45-a38f-59d2352c958d.png)

## Mobile

![Screenshot 2022-12-30 at 4 53 06 PM](https://user-images.githubusercontent.com/16139969/210052318-859e4c0e-ed98-459b-8cec-3750aa121dba.png)

