### PR TITLE
Add post deletion confirmation form

### DIFF
--- a/src/cljc/flybot/validation.cljc
+++ b/src/cljc/flybot/validation.cljc
@@ -123,7 +123,7 @@
         action       (if (:post/author post) :edition :creation)
         writer-field (if (= :creation action) :post/author :post/last-editor)]
     (-> post
-        (dissoc :post/view :post/mode)
+        (dissoc :post/view :post/mode :post/to-delete?)
         (update :post/id (if temp-id? (constantly (u/mk-uuid)) identity))
         (assoc date-field (u/mk-date))
         (assoc-in [writer-field :user/id] user-id))))

--- a/src/cljs/flybot/db.cljs
+++ b/src/cljs/flybot/db.cljs
@@ -537,9 +537,8 @@
  :evt.post-form/show-deletion
  [(rf/path :form/fields)]
  (fn [post [_ show?]]
-   (if show?
-     (assoc post :post/to-delete? true :post/view :preview) 
-     (assoc post :post/to-delete? false))))
+   (merge (assoc post :post/to-delete? show?)
+          (when show? {:post/view :preview}))))
 
 ;; ---------- Errors ----------
 

--- a/src/cljs/flybot/db.cljs
+++ b/src/cljs/flybot/db.cljs
@@ -531,6 +531,16 @@
  (fn [image-fields [_ id]]
    (get image-fields id)))
 
+;; post deletion
+
+(rf/reg-event-db
+ :evt.post-form/show-deletion
+ [(rf/path :form/fields)]
+ (fn [post [_ show?]]
+   (if show?
+     (assoc post :post/to-delete? true :post/view :preview) 
+     (assoc post :post/to-delete? false))))
+
 ;; ---------- Errors ----------
 
 (rf/reg-event-db


### PR DESCRIPTION
Closes #111
---

- Add a form for the user to confirm deletion
- Remove unnecessary trash icons in the UI for create post and post read mode

![image](https://user-images.githubusercontent.com/16139969/214473991-e109aa18-7104-49ea-9569-cf6a00e1bac6.png)