### PR TITLE
Provide a pattern to reg-sub with path option

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
            metosin/reitit                        {:mvn/version "0.5.18"}
            metosin/muuntaja                      {:mvn/version "0.6.8"}
            flybot-sg/lasagna-pull                {:git/url "https://github.com/flybot-sg/lasagna-pull.git"
-                                                  :sha     "ed0258e6293e972ba2c886939cef59c4ebbd7f89"}
+                                                  :sha     "861ef192288907b46d400769cb68a19de115ad58"}
 
            ;; backend
            ring/ring-defaults                    {:mvn/version "0.3.4"}

--- a/src/cljc/flybot/utils.cljc
+++ b/src/cljc/flybot/utils.cljc
@@ -20,3 +20,7 @@
   [k v]
   (into {} (map (juxt k identity) v)))
 
+(defn toggle
+  "Toggles 2 values."
+  [cur [v1 v2]]
+  (if (= cur v1) v2 v1))

--- a/src/cljs/flybot/components/admin_panel.cljs
+++ b/src/cljs/flybot/components/admin_panel.cljs
@@ -10,7 +10,7 @@
   [:button
    {:type "button"
     :on-click #(rf/dispatch [:evt.user.admin/toggle-mode])}
-   (if (= :edit @(rf/subscribe [:subs.user.admin/mode]))
+   (if (= :edit @(rf/subscribe [:subs/pattern '{:admin/mode ?}]))
      svg/close-icon
      svg/plus-icon )])
 
@@ -33,7 +33,7 @@
      {:type "text"
       :name "add-admin"
       :placeholder "somebody@basecity.com"
-      :value @(rf/subscribe [:subs.post.form/field :new-admin/email])
+      :value @(rf/subscribe [:subs/pattern '{:form/fields {:new-admin/email ?}}])
       :on-change #(rf/dispatch [:evt.post.form/set-field
                                 :new-admin/email
                                 (.. % -target -value)])}]]])
@@ -42,13 +42,12 @@
 
 (defn admin-section
   []
-  (when (and (= :editor @(rf/subscribe [:subs.user/mode]))
-             (some #{:admin} (->> @(rf/subscribe [:subs.user/user])
-                                  :user/roles
+  (when (and (= :editor @(rf/subscribe [:subs/pattern '{:user/mode ?}]))
+             (some #{:admin} (->> @(rf/subscribe [:subs/pattern '{:app/user {:user/roles [{:role/name ?}]}}])
                                   (map :role/name))))
     [:section.container.admin
      [:h1 "Admin"]
-     (if (= :edit @(rf/subscribe [:subs.user.admin/mode]))
+     (if (= :edit @(rf/subscribe [:subs/pattern '{:admin/mode ?}]))
        [:<>
         [errors "admin-page" [:validation-errors :failure-http-result]]
         [:form

--- a/src/cljs/flybot/components/error.cljs
+++ b/src/cljs/flybot/components/error.cljs
@@ -3,12 +3,12 @@
 
 (defn errors
   [comp-id err-ids]
-  (when @(rf/subscribe [:subs.error/errors])
+  (when @(rf/subscribe [:subs/pattern '{:app/errors ?}])
     [:div.errors
      {:key comp-id}
      (doall
       (for [id err-ids]
-        (when-let [error @(rf/subscribe [:subs.error/error id])]
+        (when-let [error @(rf/subscribe [:subs/pattern {:app/errors {id '?}}])]
           [:div.error
            {:key id}
            error])))]))

--- a/src/cljs/flybot/components/header.cljs
+++ b/src/cljs/flybot/components/header.cljs
@@ -9,7 +9,7 @@
   ([page-name text]
    (internal-link page-name text true))
   ([page-name text reitit?]
-   (let [current-page (:name @(rf/subscribe [:subs.page/current-view]))]
+   (let [current-page @(rf/subscribe [:subs/pattern '{:app/current-view {:data {:name ?}}}])]
      [:a {:href                     (rfe/href page-name)
           :on-click                 #(rf/dispatch [:evt.nav/close-navbar])
           :class                    (when (= page-name current-page) "active")
@@ -19,7 +19,7 @@
 (defn login-link
   "Link to the server for the login/logout of a user."
   []
-  (if @(rf/subscribe [:subs.user/user])
+  (if @(rf/subscribe [:subs/pattern '{:app/user ?}])
     [:a {:href "" :on-click #(rf/dispatch [:evt.user/logout])} "Logout"]
     [:a {:href "oauth/google/login"} "Login"]))
 
@@ -35,7 +35,7 @@
   (->> (navbar-content) (cons :nav) vec))
 
 (defn navbar-mobile []
-  (if @(rf/subscribe [:subs.nav/navbar-open?])
+  (if @(rf/subscribe [:subs/pattern '{:nav/navbar-open? ?}])
     (->> (navbar-content) (cons :nav.show) vec)
     (->> (navbar-content) (cons :nav.hidden) vec)))
 
@@ -43,7 +43,7 @@
   []
   [:div.pointer
    {:on-click #(rf/dispatch [:evt.app/toggle-theme])}
-   (if (= :dark @(rf/subscribe [:subs.app/theme]))
+   (if (= :dark @(rf/subscribe [:subs/pattern '{:app/theme ?}]))
      svg/sun-icon
      svg/moon-icon)])
 
@@ -51,7 +51,7 @@
   []
   [:div.pointer
    {:on-click #(rf/dispatch [:evt.user/toggle-mode])}
-   (if (= :editor @(rf/subscribe [:subs.user/mode]))
+   (if (= :editor @(rf/subscribe [:subs/pattern '{:user/mode ?}]))
      svg/eye-icon
      svg/pen-on-paper-icon)])
 
@@ -63,10 +63,12 @@
       {:alt "Flybot logo"
        :src "assets/flybot-logo.png"}]]
     [theme-logo]
-    (when @(rf/subscribe [:subs.user/user])
+    (when @(rf/subscribe [:subs/pattern '{:app/user ?}])
       [user-mode-logo])
     [navbar-web]
-    (when-let [{:user/keys [name picture]} @(rf/subscribe [:subs.user/user])]
+    (when-let [{:user/keys [name picture]} @(rf/subscribe [:subs/pattern
+                                                           '{:app/user {:user/name ? :user/picture ?}}
+                                                           [:app/user]])]
       [:div
        [:img.user-pic
         {:alt (str name " profile picture")

--- a/src/cljs/flybot/components/page.cljs
+++ b/src/cljs/flybot/components/page.cljs
@@ -13,9 +13,11 @@
 (defn page
   "Given the `page-name`, returns the page content."
   [page-name]
-  (let [sorting-method @(rf/subscribe [:subs.page.form/sorting-method page-name])
+  (let [sorting-method @(rf/subscribe [:subs/pattern
+                                       {:app/pages {page-name {:page/sorting-method '?}}}
+                                       [:app/pages page-name :page/sorting-method]])
         ordered-posts (->> @(rf/subscribe [:subs.post/posts page-name])
-                           (map h/add-hiccup)
+                           (map #(assoc % :post/hiccup-content (h/md->hiccup (:post/md-content %))))
                            (sort-posts sorting-method))
         new-post      {:post/id "new-post-temp-id"}
         posts         (conj ordered-posts new-post)]

--- a/src/cljs/flybot/components/page/page_config.cljs
+++ b/src/cljs/flybot/components/page/page_config.cljs
@@ -10,7 +10,7 @@
   [:button
    {:type "button"
     :on-click #(rf/dispatch [:evt.page/toggle-edit-mode page-name])}
-   (if (= :edit @(rf/subscribe [:subs.page/mode page-name]))
+   (if (= :edit @(rf/subscribe [:subs/pattern {:app/pages {page-name {:page/mode '?}}}]))
      svg/close-icon
      svg/pen-on-paper-post-icon)])
 
@@ -47,12 +47,12 @@
 
 (defn page-config
   [page-name]
-  (when (= :editor @(rf/subscribe [:subs.user/mode]))
+  (when (= :editor @(rf/subscribe [:subs/pattern '{:user/mode ?}]))
     [:div.page-header
      {:key (or page-name (str "config-of" page-name))}
      [:<>
       [:h1 "Order Posts"]
-      (if (= :edit @(rf/subscribe [:subs.page/mode page-name]))
+      (if (= :edit @(rf/subscribe [:subs/pattern {:app/pages {page-name {:page/mode '?}}}]))
         [:<>
          [errors page-name [:validation-errors :failure-http-result]]
          [:form

--- a/src/cljs/flybot/core.cljs
+++ b/src/cljs/flybot/core.cljs
@@ -10,7 +10,7 @@
             [re-frame.core :as rf]))
 
 (defn current-page []
-  (if-let [view (:view @(rf/subscribe [:subs.page/current-view]))]
+  (if-let [view @(rf/subscribe [:subs/pattern '{:app/current-view {:data {:view ?}}}])]
     (view)
     (page :home)))
 

--- a/src/cljs/flybot/lib/hiccup.cljs
+++ b/src/cljs/flybot/lib/hiccup.cljs
@@ -9,7 +9,7 @@
   "Extract the dark mode src from the markdown
    and add it to the hiccup props."
   [[tag {:keys [srcdark] :as props} value]] 
-  (if (and srcdark (= :dark @(rf/subscribe [:subs.app/theme])))
+  (if (and srcdark (= :dark @(rf/subscribe [:subs/pattern '{:app/theme ?}])))
     [tag (assoc props :src (:srcdark props)) value]
     [tag props value]))
 
@@ -25,9 +25,7 @@
 
 ;; ---------- Markdown to Hiccup ----------
 
-(defn add-hiccup
-  "Given a `post`, assoc the hiccup conversion of the markdown.
-   Returns the post map with the hiccup."
-  [{:post/keys [md-content] :as post}]
-  (let [hiccup (-> md-content mth/md->hiccup mth/component post-hiccup)]
-    (assoc post :post/hiccup-content hiccup)))
+(defn md->hiccup
+  "Given some markdown as a string, returns the hiccup equivalent."
+  [markdown]
+  (-> markdown mth/md->hiccup mth/component post-hiccup))

--- a/test/cljs/flybot/db_test.cljs
+++ b/test/cljs/flybot/db_test.cljs
@@ -36,13 +36,13 @@
 (deftest initialize
   (rf-test/run-test-sync
    (test-fixtures)
-   (let [current-view (rf/subscribe [:subs.page/current-view])
-         theme        (rf/subscribe [:subs.app/theme])
-         mode         (rf/subscribe [:subs.user/mode])
-         user         (rf/subscribe [:subs.user/user])
-         navbar-open? (rf/subscribe [:subs.nav/navbar-open?])
+   (let [current-view (rf/subscribe [:subs/pattern '{:app/current-view ?} [:app/current-view :data]])
+         theme        (rf/subscribe [:subs/pattern '{:app/theme ?}])
+         mode         (rf/subscribe [:subs/pattern '{:user/mode ?}])
+         user         (rf/subscribe [:subs/pattern '{:app/user ?} [:app/user]])
+         navbar-open? (rf/subscribe [:subs/pattern '{:nav/navbar-open? ?}])
          posts        (rf/subscribe [:subs.post/posts :home])
-         http-error   (rf/subscribe [:subs.error/error :failure-http-result])]
+         http-error   (rf/subscribe [:subs/pattern '{:app/errors {:failure-http-result ?}}])]
      ;;---------- SERVER ERROR
      ;; Mock failure http request
      (rf/reg-fx :http-xhrio
@@ -73,7 +73,7 @@
 (deftest theme
   (rf-test/run-test-sync
    (test-fixtures)
-   (let [theme (rf/subscribe [:subs.app/theme])]
+   (let [theme (rf/subscribe [:subs/pattern '{:app/theme ?}])]
      (testing "Initial theme is :dark."
        (is (= :dark @theme)))
      
@@ -87,7 +87,7 @@
 (deftest navbar
   (rf-test/run-test-sync
    (test-fixtures)
-   (let [navbar-open? (rf/subscribe [:subs.nav/navbar-open?])]
+   (let [navbar-open? (rf/subscribe [:subs/pattern '{:nav/navbar-open? ?}])]
      (testing "navbar is closed."
        (is (false? @navbar-open?)))
      
@@ -106,7 +106,7 @@
 (deftest user
   (rf-test/run-test-sync
    (test-fixtures)
-   (let [mode (rf/subscribe [:subs.user/mode])]
+   (let [mode (rf/subscribe [:subs/pattern '{:user/mode ?}])]
      (testing "Initial mode is :reader."
        (is (= :reader @mode)))
      
@@ -120,9 +120,11 @@
 (deftest page
   (rf-test/run-test-sync
    (test-fixtures)
-   (let [mode               (rf/subscribe [:subs.page/mode :home])
-         sorting-method     (rf/subscribe [:subs.page.form/sorting-method :home])
-         validation-error   (rf/subscribe [:subs.error/error :validation-errors])
+   (let [mode               (rf/subscribe [:subs/pattern '{:app/pages {:home {:page/mode ?}}}])
+         sorting-method     (rf/subscribe [:subs/pattern
+                                           '{:app/pages {:home {:page/sorting-method ?}}}
+                                           [:app/pages :home :page/sorting-method]])
+         validation-error   (rf/subscribe [:subs/pattern '{:app/errors {:validation-errors ?}}])
          new-sorting-method {:sort/type :post/last-edit-date :sort/direction :ascending}]
      (testing "Initial mode is :read."
        (is (= :read @mode)))
@@ -164,12 +166,12 @@
   (with-redefs [utils/mk-date (constantly s/post-1-edit-date)]
     (rf-test/run-test-sync
      (test-fixtures)
-     (let [p1-mode          (rf/subscribe [:subs.post/mode s/post-1-id])
-           p1-form          (rf/subscribe [:subs.post.form/fields])
-           p1-preview       (rf/subscribe [:subs.post.form/field :post/view])
+     (let [p1-mode          (rf/subscribe [:subs/pattern {:app/posts {s/post-1-id {:post/mode '?}}}])
+           p1-form          (rf/subscribe [:subs/pattern '{:form/fields ?} [:form/fields]])
+           p1-preview       (rf/subscribe [:subs/pattern '{:form/fields {:post/view ?}}])
            posts            (rf/subscribe [:subs.post/posts :home])
-           errors           (rf/subscribe [:subs.error/errors])
-           validation-error (rf/subscribe [:subs.error/error :validation-errors])
+           errors           (rf/subscribe [:subs/pattern '{:app/errors ?} [:app/errors]])
+           validation-error (rf/subscribe [:subs/pattern '{:app/errors {:validation-errors ?}}])
            new-post-1       (assoc s/post-1
                                    :post/md-content     "#New Content 1"
                                    :post/last-edit-date (utils/mk-date))]
@@ -230,8 +232,8 @@
                           :post/mode :edit
                           :post/author {:user/id "bob-id" :user/name "Bob"}
                           :post/creation-date (utils/mk-date)}
-           new-post-mode (rf/subscribe [:subs.post/mode temp-id])
-           new-post-form (rf/subscribe [:subs.post.form/fields])
+           new-post-mode (rf/subscribe [:subs/pattern {:app/posts {temp-id {:post/mode '?}}}])
+           new-post-form (rf/subscribe [:subs/pattern '{:form/fields ?} [:form/fields]])
            posts         (rf/subscribe [:subs.post/posts :home])
            new-post      (assoc empty-post
                                 :post/md-content "#New Content 1")]
@@ -272,8 +274,8 @@
   (rf-test/run-test-sync
    (test-fixtures)
    (let [posts   (rf/subscribe [:subs.post/posts :home])
-         p1-form (rf/subscribe [:subs.post.form/fields])
-         p1-mode (rf/subscribe [:subs.post/mode s/post-1-id])]
+         p1-form (rf/subscribe [:subs/pattern '{:form/fields ?} [:form/fields]])
+         p1-mode (rf/subscribe [:subs/pattern {:app/posts {s/post-1-id {:post/mode '?}}}])]
      ;;---------- DELETE POST - READ MODE
      (rf/reg-fx :http-xhrio
                 (fn [_]


### PR DESCRIPTION
Closes #106
---

- Add a `re-frame/reg-sub` that takes a pattern and optional path to get-in once pulled.

By default it returns the leaf value, similar to what would be returned with a regular `reg-sub`. However, in case we want to fetch a whole map or nested maps (a post for instance), we can provide a `path` to the keys we want to get.