### PR TITLE
Add re-frame logic to deal with screens navigation

### DIFF
--- a/client/common/src/flybot/client/common/db/event.cljs
+++ b/client/common/src/flybot/client/common/db/event.cljs
@@ -270,7 +270,7 @@
                           :post/author (-> db :app/user (select-keys [:user/id :user/name]))
                           :post/creation-date (utils/mk-date)})}
      {:http-xhrio {:method          :post
-                   :uri             "/posts/post"
+                   :uri             "/posts/post" ;; use "http://localhost:9500/posts/post" for RN as for now
                    :params          {:posts
                                      {(list :post :with [post-id])
                                       {:post/id '?

--- a/client/mobile/src/flybot/client/mobile/core/db/event.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/db/event.cljs
@@ -13,7 +13,6 @@
                    :user/mode        :reader
                    :admin/mode       :read
                    :navigator/ref    nil
-                   :screen-params    nil
                    :nav/navbar-open? false)
       :http-xhrio {:method          :post
                    :uri             "http://localhost:9500/pages/all"
@@ -56,8 +55,7 @@
 (rf/reg-event-fx
  :evt.nav/navigate
  (fn [{:keys [db]} [_ view-id params]]
-   {:db (assoc-in db [:screen-params] params)
-    :fx [[:fx.nav/react-navigate [(:navigator/ref db) view-id]]]}))
+   {:fx [[:fx.nav/react-navigate [(:navigator/ref db) view-id params]]]}))
 
 (rf/reg-event-db
  :evt.nav/set-ref

--- a/client/mobile/src/flybot/client/mobile/core/db/event.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/db/event.cljs
@@ -6,12 +6,14 @@
 (rf/reg-event-fx
  :evt.app/initialize
  (fn [{:keys [db local-store-theme]} _]
-   (let [app-theme    (or local-store-theme :dark)]
+   (let [app-theme (or local-store-theme :dark)]
      {:db         (assoc
                    db
                    :app/theme        app-theme
                    :user/mode        :reader
                    :admin/mode       :read
+                   :navigator/ref    nil
+                   :screen-params    nil
                    :nav/navbar-open? false)
       :http-xhrio {:method          :post
                    :uri             "http://localhost:9500/pages/all"
@@ -50,3 +52,14 @@
                    :response-format (edn-response-format {:keywords? true})
                    :on-success      [:fx.http/all-success]
                    :on-failure      [:fx.http/failure]}})))
+
+(rf/reg-event-fx
+ :evt.nav/navigate
+ (fn [{:keys [db]} [_ view-id params]]
+   {:db (assoc-in db [:screen-params] params)
+    :fx [[:fx.nav/react-navigate [(:navigator/ref db) view-id]]]}))
+
+(rf/reg-event-db
+ :evt.nav/set-ref
+ (fn [db [_ r]]
+   (assoc db :navigator/ref r)))

--- a/client/mobile/src/flybot/client/mobile/core/db/fx.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/db/fx.cljs
@@ -1,2 +1,17 @@
 (ns flybot.client.mobile.core.db.fx
-  (:require [flybot.client.common.db.fx]))
+  (:require [flybot.client.common.db.fx]
+            [flybot.client.mobile.core.utils :refer [cljs->js]]
+            [re-frame.core :as rf]))
+
+(defn navigate
+  [nav-ref route-name params]
+  (.navigate
+   nav-ref
+   (cljs->js
+    {:name route-name
+     :params params})))
+
+(rf/reg-fx
+ :fx.nav/react-navigate
+ (fn [[nav-ref view-id]]
+   (navigate nav-ref view-id nil)))

--- a/client/mobile/src/flybot/client/mobile/core/db/fx.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/db/fx.cljs
@@ -9,9 +9,9 @@
    nav-ref
    (cljs->js
     {:name route-name
-     :params params})))
+     :params (if (uuid? params) (str params) params)})))
 
 (rf/reg-fx
  :fx.nav/react-navigate
- (fn [[nav-ref view-id]]
-   (navigate nav-ref view-id nil)))
+ (fn [[nav-ref view-id params]]
+   (navigate nav-ref view-id params)))

--- a/client/mobile/src/flybot/client/mobile/core/styles.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/styles.cljs
@@ -5,23 +5,3 @@
    :dark "#18181b"
    :blue "#0ea5e9"
    :green "#22c55e"})
-
-(def blog-post-styles
-  "Styles props to be used with the Markdown object."
-  {:view {:align-self "stretch"}
-   :text {:color (:dark colors)}
-   :heading-1 {:color (:blue colors)
-               :text-align "center"
-               :text-transform "uppercase"
-               :padding-top 5
-               :padding-bottom 5}
-   :heading-2 {:padding-top 5
-               :padding-bottom 5}
-   :heading-3 {:color (:blue colors)
-               :padding-top 5
-               :padding-bottom 5}
-   :heading-4 {:padding-top 5
-               :padding-bottom 5}
-   :heading-5 {:color (:blue colors)
-               :padding-top 5
-               :padding-bottom 5}})

--- a/client/mobile/src/flybot/client/mobile/core/utils.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/utils.cljs
@@ -33,3 +33,9 @@
   (if (str/starts-with? path "http")
     path
     (str "https://www.flybot.sg/" path)))
+
+(defn nav-params
+  "Given the navigator object ref, returns the current params"
+  [nav-ref]
+  (let [params (when nav-ref (js->cljs (.-params (. nav-ref getCurrentRoute))))]
+    (if (string? params) (uuid params) params)))

--- a/client/mobile/src/flybot/client/mobile/core/view.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/view.cljs
@@ -1,0 +1,67 @@
+(ns flybot.client.mobile.core.view
+  (:require ["@react-navigation/bottom-tabs" :as tab-nav]
+            ["@react-navigation/native" :refer [NavigationContainer]]
+            ["react-native-vector-icons/Ionicons" :as icon]
+            [flybot.client.mobile.core.styles :refer [colors]]
+            [flybot.client.mobile.core.utils :refer [cljs->js js->cljs]]
+            [flybot.client.mobile.core.view.blog :refer [blog]]
+            [re-frame.core :as rf]
+            [reagent.core :as r]
+            [reagent.react-native :as rrn]))
+
+(def bottom-tab-nav (tab-nav/createBottomTabNavigator))
+(def default-icon (.-default icon))
+
+(defn tab-icon
+  [route-name]
+  [:> default-icon
+   (case route-name
+     "home" {:name "ios-home"
+             :size 30
+             :color (:blue colors)}
+     "blog" {:name "create"
+             :size 30
+             :color (:blue colors)}
+     :default)])
+
+(defn home
+  []
+  [rrn/view
+   {:style {:background-color (:light colors)
+            :border-color (:green colors)
+            :flex 1
+            :justify-content "center"}}
+   [rrn/image
+    {:style {:flex 1
+             :resize-mode "contain"}
+     :source {:uri "https://www.flybot.sg/assets/flybot-logo.png"}
+     :alt "flybot-logo"}]])
+
+
+
+(defn screen-otpions
+  [options]
+  (cljs->js
+   {:title "Flybot App"
+    :header-style {:background-color (:dark colors)
+                   :height 100}
+    :tab-bar-style {:background-color (:dark colors)}
+    :tab-bar-label-style {:font-size 15}
+    :tab-bar-active-tint-color (:green colors)
+    :header-tint-color (:blue colors)
+    :header-title-style {:font-size 30
+                         :text-align "center"}
+    :tab-bar-icon (fn [_]
+                    (let [route-name (-> options js->cljs :route :name)]
+                      (r/as-element [tab-icon route-name])))}))
+
+(defn app []
+  [:> NavigationContainer {:ref (fn [el] (rf/dispatch [:evt.nav/set-ref el]))}
+   [:> (.-Navigator bottom-tab-nav) {:screen-options screen-otpions
+                                     :initial-route-name "blog"}
+    [:> (.-Screen bottom-tab-nav) {:name "home"
+                                   :component (r/reactify-component home)
+                                   :options {:title "Home"}}]
+    [:> (.-Screen bottom-tab-nav) {:name "blog"
+                                   :component (r/reactify-component blog)
+                                   :options {:title "Blog"}}]]])

--- a/client/mobile/src/flybot/client/mobile/core/view.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/view.cljs
@@ -55,8 +55,18 @@
                     (let [route-name (-> options js->cljs :route :name)]
                       (r/as-element [tab-icon route-name])))}))
 
+(defonce nav-state (atom nil))
+
+(defn- persist-state! [state-obj]
+  (js/Promise.
+   (fn [resolve _]
+     (reset! nav-state state-obj)
+     (resolve true))))
+
 (defn app []
-  [:> NavigationContainer {:ref (fn [el] (rf/dispatch [:evt.nav/set-ref el]))}
+  [:> NavigationContainer {:ref (fn [el] (rf/dispatch [:evt.nav/set-ref el]))
+                           :on-state-change persist-state!
+                           :initial-state @nav-state}
    [:> (.-Navigator bottom-tab-nav) {:screen-options screen-otpions
                                      :initial-route-name "blog"}
     [:> (.-Screen bottom-tab-nav) {:name "home"

--- a/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
@@ -1,0 +1,157 @@
+(ns flybot.client.mobile.core.view.blog
+  (:require ["react-native-markdown-package" :as Markdown]
+            ["react-native-vector-icons/Ionicons" :as icon]
+            ["@react-navigation/native-stack" :as stack-nav]
+            [clojure.string :as str]
+            [flybot.client.mobile.core.styles :refer [colors]]
+            [flybot.client.mobile.core.utils :refer [js->cljs] :as utils]
+            [re-frame.core :as rf]
+            [reagent.core :as r]
+            [reagent.react-native :as rrn]))
+
+(def markdown (.-default Markdown))
+(def default-icon (.-default icon))
+(def stack-nav (stack-nav/createNativeStackNavigator))
+
+(def post-styles
+  "Styles props to be used with the Markdown object."
+  {:view {:align-self "stretch"}
+   :text {:color (:dark colors)}
+   :heading-1 {:color (:blue colors)
+               :text-align "center"
+               :text-transform "uppercase"
+               :padding-top 5
+               :padding-bottom 5}
+   :heading-2 {:padding-top 5
+               :padding-bottom 5}
+   :heading-3 {:color (:blue colors)
+               :padding-top 5
+               :padding-bottom 5}
+   :heading-4 {:padding-top 5
+               :padding-bottom 5}
+   :heading-5 {:color (:blue colors)
+               :padding-top 5
+               :padding-bottom 5}})
+
+(defn post-author
+  [show-authors? author show-dates? date authored?]
+  [rrn/view
+   {:style {:flex-direction "row"
+            :align-items "center"}}
+   (when (or show-authors? show-dates?)
+     [:> default-icon
+      {:name "create"
+       :size 30
+       :color (:green colors)}])
+   (when show-authors?
+     [rrn/text
+      {:style {:color (:green colors)
+               :padding 5}}
+      (:author/name author)])
+   (when show-dates?
+     [rrn/text
+      {:style {:color (:green colors)
+               :padding 5}}
+      (utils/format-date date)])
+   (when (or show-authors? show-dates?)
+     [rrn/text
+      {:style {:color (:green colors)
+               :padding 5}}
+      (if authored? "[Authored]" "[Edited]")])])
+
+(defn post-full
+  [{:post/keys [md-content image-beside
+                show-dates? creation-date last-edit-date
+                show-authors? author last-editor]}]
+  [rrn/scroll-view
+   {:style {:padding 10
+            :border-width 3
+            :border-color (:green colors)}}
+   [rrn/image
+    {:style {:resize-mode "contain"
+             :height 200}
+     :source {:uri (-> image-beside :image/src utils/format-image)}
+     :alt (-> image-beside :image/alt)}]
+   [rrn/view
+    {:style {:padding 10
+             :border-top-width 1
+             :border-top-color (:blue colors)
+             :border-bottom-width 1
+             :border-bottom-color (:blue colors)}}
+    [post-author show-authors? author show-dates? creation-date true]
+    [post-author show-authors? last-editor show-dates? last-edit-date false]]
+   [rrn/view
+    {}
+    [:> markdown
+     {:styles post-styles}
+     md-content]]])
+
+(defn md-title
+  "Returns the title # of the given markdown
+   Assume that `md` starts with the title."
+  [md]
+  (-> md (str/split #"#" 3) second (str/split #"\n") first str/trim))
+
+(defn post-short
+  "Display a short version of the post"
+  [{:keys [id md-content image-beside creation-date author]}]
+  [rrn/touchable-highlight
+   {:on-press #(rf/dispatch [:evt.nav/navigate (str "post-" id)])
+    :underlay-color (:blue colors)}
+   [rrn/view
+    {:style {:flex-direction "row"
+             :gap 10
+             :align-items "center"
+             :padding 10
+             :border-bottom-width 3
+             :border-bottom-color (:green colors)}}
+    [rrn/image
+     {:style {:resize-mode "contain"
+              :height 50
+              :width 50}
+      :source {:uri (-> image-beside :src utils/format-image)}
+      :alt (-> image-beside :alt)}]
+    [rrn/view
+     {:style {:gap 5}}
+     [rrn/text
+      {:style {:font-size 20}}
+      (md-title md-content)]
+     [rrn/text
+      {:style {:color (:green colors)}}
+      (str (:name author) " - " (utils/format-date creation-date))]]]])
+
+(defn posts-list
+  []
+  [rrn/view
+   {:style {:background-color (:light colors)
+            :flex 1
+            :justify-content "center"}}
+   [rrn/flat-list
+    {:data @(rf/subscribe [:subs.post/posts :blog])
+     :key-extractor (fn [item]
+                      (-> item js->cljs :id))
+     :render-item (fn [item]
+                    (let [post (-> item js->cljs :item)]
+                      (r/as-element
+                       [post-short post])))}]])
+
+(defn posts-list-screen
+  []
+  [:> (.-Screen stack-nav) {:name "posts-list"
+                            :component (r/reactify-component posts-list)}])
+
+(defn post-screen
+  [post]
+  [:> (.-Screen stack-nav) {:name (str "post-" (:post/id post))
+                            :component (r/reactify-component
+                                        (fn [] (post-full post)))}])
+
+(defn blog
+  []
+  (let [posts @(rf/subscribe [:subs.post/posts :blog])]
+    (vec
+     (concat
+      [:> (.-Navigator stack-nav) {:initial-route-name "posts-list"
+                                   :screen-options {:animation "slide_from_right"}}]
+      [(posts-list-screen)]
+      (map post-screen posts)))))

--- a/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
@@ -49,7 +49,7 @@
      [rrn/text
       {:style {:color (:green colors)
                :padding 5}}
-      (:author/name author)])
+      (:user/name author)])
    (when show-dates?
      [rrn/text
       {:style {:color (:green colors)

--- a/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
@@ -2,6 +2,7 @@
   (:require ["@react-navigation/native-stack" :as stack-nav]
             ["react-native-markdown-package" :as Markdown]
             ["react-native-vector-icons/Ionicons" :as icon]
+            ["react-native-bouncy-checkbox" :as BouncyCheckbox]
             [clojure.string :as str]
             [flybot.client.mobile.core.styles :refer [colors]]
             [flybot.client.mobile.core.utils :refer [js->cljs] :as utils]
@@ -11,6 +12,7 @@
 
 (def markdown (.-default Markdown))
 (def default-icon (.-default icon))
+(def check-box (.-default BouncyCheckbox))
 (def stack-nav (stack-nav/createNativeStackNavigator))
 
 ;;---------- Read Post Screen -----------
@@ -98,7 +100,8 @@
   [post]
   [rrn/button
    {:title "Edit Post"
-    :on-press #(rf/dispatch [:evt.nav/navigate (str "post-edit-" (:post/id post))])}])
+    :on-press #(do (rf/dispatch [:evt.nav/navigate (str "post-edit-" (:post/id post))])
+                   (rf/dispatch [:evt.post.form/autofill (:post/id post)]))}])
 
 (defn post-read-screen
   [post]
@@ -113,13 +116,59 @@
 ;;---------- Edit Post Screen -----------
 
 (defn post-edit
-  [{:post/keys [md-content]}]
+  [_]
   [rrn/scroll-view
    {:style {:padding 10
             :border-width 3
-            :border-color (:green colors)}}
-   ;; TODO
-   [rrn/text {} (md-title md-content)]])
+            :border-color (:green colors)}
+    :content-container-style {:gap 10}}
+   [rrn/text
+    {:style {:text-align "center"}}
+    "Side Image source for LIGHT mode:"]
+   [rrn/text-input
+    {:default-value @(rf/subscribe [:subs/pattern '{:form/fields {:post/image-beside {:image/src ?}}}])
+     :on-change-text #(rf/dispatch [:evt.form.image/set-field :image/src %])
+     :style {:border-width 1
+             :padding 10}}]
+   [rrn/text
+    {:style {:text-align "center"}}
+    "Side Image source for DARK mode:"]
+   [rrn/text-input
+    {:default-value @(rf/subscribe [:subs/pattern '{:form/fields {:post/image-beside {:image/src-dark ?}}}])
+     :on-change-text #(rf/dispatch [:evt.form.image/set-field :image/src-dark %])
+     :style {:border-width 1
+             :padding 10}}]
+   [rrn/text
+    {:style {:text-align "center"}}
+    "Side Image description:"]
+   [rrn/text-input
+    {:default-value @(rf/subscribe [:subs/pattern '{:form/fields {:post/image-beside {:image/alt ?}}}])
+     :on-change-text #(rf/dispatch [:evt.form.image/set-field :image/alt %])
+     :style {:border-width 1
+             :padding 10}}]
+   [:> check-box
+    {:text "Show Dates"
+     :is-checked @(rf/subscribe [:subs/pattern '{:form/fields {:post/show-dates? ?}}])
+     :text-style {:text-decoration-line "none"}
+     :on-press #(rf/dispatch [:evt.post.form/set-field :post/show-dates? %])
+     :fill-color (:green colors)
+     :style {:padding 10}}]
+   [:> check-box
+    {:text "Show Authors"
+     :is-checked @(rf/subscribe [:subs/pattern '{:form/fields {:post/show-authors? ?}}])
+     :text-style {:text-decoration-line "none"}
+     :on-press #(rf/dispatch [:evt.post.form/set-field :post/show-authors? %])
+     :fill-color (:green colors)
+     :style {:padding 10}}]
+   [rrn/text
+    {:style {:text-align "center"}}
+    "Post Content in Markdown:"]
+   [rrn/text-input
+    {:default-value @(rf/subscribe [:subs/pattern '{:form/fields {:post/md-content ?}}])
+     :on-change-text #(rf/dispatch [:evt.post.form/set-field :post/md-content %])
+     :multiline true
+     :style {:border-width 1
+             :padding 10}}]])
 
 (defn post-edit-screen
   [post]

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@react-navigation/native-stack": "^6.9.10",
         "react": "18.2.0",
         "react-native": "0.71.2",
+        "react-native-bouncy-checkbox": "^3.0.7",
         "react-native-gesture-handler": "^2.9.0",
         "react-native-markdown-package": "^1.8.2",
         "react-native-safe-area-context": "^4.5.0",
@@ -12946,6 +12947,15 @@
       },
       "peerDependencies": {
         "react": "18.2.0"
+      }
+    },
+    "node_modules/react-native-bouncy-checkbox": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/react-native-bouncy-checkbox/-/react-native-bouncy-checkbox-3.0.7.tgz",
+      "integrity": "sha512-776TgMGt9wTpOQA1TcvFjL5VUn6o945wFYf3Ztqva62/vT2o3JAezLiP7hYh2Svd+PewfWBYSPMs4jeaSoS8Sg==",
+      "peerDependencies": {
+        "react": ">= 16.x.x",
+        "react-native": ">= 0.55.x"
       }
     },
     "node_modules/react-native-codegen": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@react-navigation/bottom-tabs": "^6.5.4",
         "@react-navigation/native": "^6.1.3",
-        "@react-navigation/native-stack": "^6.9.9",
+        "@react-navigation/native-stack": "^6.9.10",
         "react": "18.2.0",
         "react-native": "0.71.2",
         "react-native-gesture-handler": "^2.9.0",
@@ -4414,9 +4414,9 @@
       }
     },
     "node_modules/@react-navigation/elements": {
-      "version": "1.3.14",
-      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-1.3.14.tgz",
-      "integrity": "sha512-RBbPhYq+KNFPAkWPaHB9gypq0jTGp/0fkMwRLToJ8jkLtWG4LV+JoQ/erFQnVARkR3Q807n0VnES15EYP4ITMQ==",
+      "version": "1.3.15",
+      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-1.3.15.tgz",
+      "integrity": "sha512-CR4CEYJVY0OLyeLQi9N3Z2o4K47gXctvFxfZizDuW1xFtCJbA0eGvpjSLXEWHoY0hFjrlC6KinpdepGHVxhYIg==",
       "peerDependencies": {
         "@react-navigation/native": "^6.0.0",
         "react": "*",
@@ -4440,11 +4440,11 @@
       }
     },
     "node_modules/@react-navigation/native-stack": {
-      "version": "6.9.9",
-      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-6.9.9.tgz",
-      "integrity": "sha512-FIbTCEjqAt6guQ90lKIDvOfTo5vtKGG+aQTtHMdTV9JLGnS6gFsBgXmv5hvWLkyd426Nc04mpZXPTK7d80v/LQ==",
+      "version": "6.9.10",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-6.9.10.tgz",
+      "integrity": "sha512-dSazcWNxHg4qkid/AxFRvbhRtNXy/RqE00h/Qp+d7aBN0TwrOJn8mH/Inkkf4pHAntMbj0+mVAlKfxKmyLEGlA==",
       "dependencies": {
-        "@react-navigation/elements": "^1.3.14",
+        "@react-navigation/elements": "^1.3.15",
         "warn-once": "^0.1.0"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@react-navigation/bottom-tabs": "^6.5.4",
     "@react-navigation/native": "^6.1.3",
-    "@react-navigation/native-stack": "^6.9.9",
+    "@react-navigation/native-stack": "^6.9.10",
     "react": "18.2.0",
     "react-native": "0.71.2",
     "react-native-gesture-handler": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@react-navigation/native-stack": "^6.9.10",
     "react": "18.2.0",
     "react-native": "0.71.2",
+    "react-native-bouncy-checkbox": "^3.0.7",
     "react-native-gesture-handler": "^2.9.0",
     "react-native-markdown-package": "^1.8.2",
     "react-native-safe-area-context": "^4.5.0",


### PR DESCRIPTION
Closes #121
---

## Features

- add one screen with the list of posts
- add one screen for each post for `read` mode
- add one screen for each post for `edit` mode
- store the ref to the react navigation object in the re-frame db
- use re-frame dispatch to go to next navigation route

## UI

### Posts list screen

![Screenshot 2023-02-24 at 10 59 18 AM](https://user-images.githubusercontent.com/16139969/221081361-29d3b1c9-9d62-40f8-b5c6-296fd55b993f.png)

### Post screen read mode

![Screenshot 2023-02-24 at 11 25 26 AM](https://user-images.githubusercontent.com/16139969/221084642-dc99c407-e975-45ca-97ad-53350aa61b8a.png)

### Post screen edit mode

![Screenshot 2023-02-24 at 4 13 42 PM](https://user-images.githubusercontent.com/16139969/221126967-4148e99e-bbba-43a7-b4eb-2d5bfb726c0f.png)