### PR TITLE
Use google closure-defines to deal with base-uri

### DIFF
--- a/client/common/src/flybot/client/common/db/event.cljs
+++ b/client/common/src/flybot/client/common/db/event.cljs
@@ -6,6 +6,9 @@
             [day8.re-frame.http-fx]
             [re-frame.core :as rf]))
 
+;; Overridden by the figwheel config option :closure-defines
+(goog-define BASE-URI "")
+
 ;; ---------- http ----------
 
 (rf/reg-event-db
@@ -102,7 +105,7 @@
  :evt.user/logout
  (fn [_ _]
    {:http-xhrio {:method          :get
-                 :uri             "/users/logout"
+                 :uri             (str BASE-URI "/users/logout")
                  :response-format (edn-response-format {:keywords? true})
                  :on-success      [:fx.http/logout-success]
                  :on-failure      [:fx.http/failure]}}))
@@ -114,7 +117,7 @@
      (if (:errors new-admin-email)
        {:fx [[:dispatch [:evt.error/set-validation-errors (valid/error-msg new-admin-email)]]]}
        {:http-xhrio {:method          :post
-                     :uri             "/users/new-role/admin"
+                     :uri             (str BASE-URI "/users/new-role/admin")
                      :params          {:users
                                        {:new-role
                                         {(list :admin :with [new-admin-email])
@@ -151,7 +154,7 @@
      (if (:errors page)
        {:fx [[:dispatch [:evt.error/set-validation-errors (valid/error-msg page)]]]}
        {:http-xhrio {:method          :post
-                     :uri             "/pages/new-page"
+                     :uri             (str BASE-URI "/pages/new-page")
                      :params          {:pages
                                        {(list :new-page :with [page])
                                         {:page/name '?}}}
@@ -207,7 +210,7 @@
  (fn [{:keys [db]} [_ post-id]]
    (let [user-id (-> db :app/user :user/id)]
      {:http-xhrio {:method          :post
-                   :uri             "/posts/removed-post"
+                   :uri             (str BASE-URI "/posts/removed-post")
                    :params          {:posts
                                      {(list :removed-post :with [post-id user-id])
                                       {:post/id '?}}}
@@ -234,7 +237,7 @@
      (if (:errors post)
        {:fx [[:dispatch [:evt.error/set-validation-errors (valid/error-msg post)]]]}
        {:http-xhrio {:method          :post
-                     :uri             "/posts/new-post"
+                     :uri             (str BASE-URI "/posts/new-post")
                      :params          {:posts
                                        {(list :new-post :with [post])
                                         {:post/id '?
@@ -270,7 +273,7 @@
                           :post/author (-> db :app/user (select-keys [:user/id :user/name]))
                           :post/creation-date (utils/mk-date)})}
      {:http-xhrio {:method          :post
-                   :uri             "/posts/post" ;; use "http://localhost:9500/posts/post" for RN as for now
+                   :uri             (str BASE-URI "/posts/post")
                    :params          {:posts
                                      {(list :post :with [post-id])
                                       {:post/id '?

--- a/client/common/src/flybot/client/common/db/event.cljs
+++ b/client/common/src/flybot/client/common/db/event.cljs
@@ -9,6 +9,11 @@
 ;; Overridden by the figwheel config option :closure-defines
 (goog-define BASE-URI "")
 
+(defn base-uri
+  "Given the relative `path`, use the BASE-URI to build the absolute path uri."
+  [path]
+  (str BASE-URI path))
+
 ;; ---------- http ----------
 
 (rf/reg-event-db
@@ -105,7 +110,7 @@
  :evt.user/logout
  (fn [_ _]
    {:http-xhrio {:method          :get
-                 :uri             (str BASE-URI "/users/logout")
+                 :uri             (base-uri "/users/logout")
                  :response-format (edn-response-format {:keywords? true})
                  :on-success      [:fx.http/logout-success]
                  :on-failure      [:fx.http/failure]}}))
@@ -117,7 +122,7 @@
      (if (:errors new-admin-email)
        {:fx [[:dispatch [:evt.error/set-validation-errors (valid/error-msg new-admin-email)]]]}
        {:http-xhrio {:method          :post
-                     :uri             (str BASE-URI "/users/new-role/admin")
+                     :uri             (base-uri "/users/new-role/admin")
                      :params          {:users
                                        {:new-role
                                         {(list :admin :with [new-admin-email])
@@ -154,7 +159,7 @@
      (if (:errors page)
        {:fx [[:dispatch [:evt.error/set-validation-errors (valid/error-msg page)]]]}
        {:http-xhrio {:method          :post
-                     :uri             (str BASE-URI "/pages/new-page")
+                     :uri             (base-uri "/pages/new-page")
                      :params          {:pages
                                        {(list :new-page :with [page])
                                         {:page/name '?}}}
@@ -210,7 +215,7 @@
  (fn [{:keys [db]} [_ post-id]]
    (let [user-id (-> db :app/user :user/id)]
      {:http-xhrio {:method          :post
-                   :uri             (str BASE-URI "/posts/removed-post")
+                   :uri             (base-uri "/posts/removed-post")
                    :params          {:posts
                                      {(list :removed-post :with [post-id user-id])
                                       {:post/id '?}}}
@@ -237,7 +242,7 @@
      (if (:errors post)
        {:fx [[:dispatch [:evt.error/set-validation-errors (valid/error-msg post)]]]}
        {:http-xhrio {:method          :post
-                     :uri             (str BASE-URI "/posts/new-post")
+                     :uri             (base-uri "/posts/new-post")
                      :params          {:posts
                                        {(list :new-post :with [post])
                                         {:post/id '?
@@ -273,7 +278,7 @@
                           :post/author (-> db :app/user (select-keys [:user/id :user/name]))
                           :post/creation-date (utils/mk-date)})}
      {:http-xhrio {:method          :post
-                   :uri             (str BASE-URI "/posts/post")
+                   :uri             (base-uri "/posts/post")
                    :params          {:posts
                                      {(list :post :with [post-id])
                                       {:post/id '?

--- a/client/mobile/src/flybot/client/mobile/core/db/event.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/db/event.cljs
@@ -1,10 +1,7 @@
 (ns flybot.client.mobile.core.db.event
-  (:require [flybot.client.common.db.event]
+  (:require [flybot.client.common.db.event :refer [base-uri]]
             [ajax.edn :refer [edn-request-format edn-response-format]]
             [re-frame.core :as rf]))
-
-;; Overridden by the figwheel config option :closure-defines
-(goog-define BASE-URI "")
 
 (rf/reg-event-fx
  :evt.app/initialize
@@ -18,7 +15,7 @@
                    :navigator/ref    nil
                    :nav/navbar-open? false)
       :http-xhrio {:method          :post
-                   :uri             (str BASE-URI "/pages/all")
+                   :uri             (base-uri "/pages/all")
                    :params {:pages
                             {(list :all :with [])
                              [{:page/name '?

--- a/client/mobile/src/flybot/client/mobile/core/db/event.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/db/event.cljs
@@ -3,6 +3,9 @@
             [ajax.edn :refer [edn-request-format edn-response-format]]
             [re-frame.core :as rf]))
 
+;; Overridden by the figwheel config option :closure-defines
+(goog-define BASE-URI "")
+
 (rf/reg-event-fx
  :evt.app/initialize
  (fn [{:keys [db local-store-theme]} _]
@@ -15,7 +18,7 @@
                    :navigator/ref    nil
                    :nav/navbar-open? false)
       :http-xhrio {:method          :post
-                   :uri             "http://localhost:9500/pages/all"
+                   :uri             (str BASE-URI "/pages/all")
                    :params {:pages
                             {(list :all :with [])
                              [{:page/name '?

--- a/ios.cljs.edn
+++ b/ios.cljs.edn
@@ -1,2 +1,4 @@
 ^{:react-native :cli}
-{:main flybot.client.mobile.core}
+{:main flybot.client.mobile.core
+ :closure-defines {flybot.client.common.db.event/BASE-URI "http://localhost:9500"
+                   flybot.client.mobile.core.db.event/BASE-URI "http://localhost:9500"}}

--- a/ios.cljs.edn
+++ b/ios.cljs.edn
@@ -1,4 +1,3 @@
 ^{:react-native :cli}
 {:main flybot.client.mobile.core
- :closure-defines {flybot.client.common.db.event/BASE-URI "http://localhost:9500"
-                   flybot.client.mobile.core.db.event/BASE-URI "http://localhost:9500"}}
+ :closure-defines {flybot.client.common.db.event/BASE-URI "http://localhost:9500"}}


### PR DESCRIPTION
Closes #123
---

- override custom `BASE-URI` google closure var using figwheel config file `ios.cljs.edn` for react native.
- for the web, do anything as relative paths are fine in http request URIs.