### PR TITLE
120 edit post mobile

### DIFF
--- a/client/common/src/flybot/client/common/db/event.cljs
+++ b/client/common/src/flybot/client/common/db/event.cljs
@@ -299,7 +299,8 @@
                    :format          (edn-request-format {:keywords? true})
                    :response-format (edn-response-format {:keywords? true})
                    :on-success      [:fx.http/post-success]
-                   :on-failure      [:fx.http/failure]}})))
+                   :on-failure      [:fx.http/failure]}
+      :fx [[:dispatch [:evt.error/clear-errors]]]})))
 
 (rf/reg-event-db
  :evt.post.form/set-field

--- a/client/mobile/src/flybot/client/mobile/core/db/event.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/db/event.cljs
@@ -1,5 +1,6 @@
 (ns flybot.client.mobile.core.db.event
   (:require [flybot.client.common.db.event :refer [base-uri]]
+            [flybot.client.mobile.core.navigation :as nav]
             [ajax.edn :refer [edn-request-format edn-response-format]]
             [re-frame.core :as rf]))
 
@@ -12,7 +13,7 @@
                    :app/theme        app-theme
                    :user/mode        :reader
                    :admin/mode       :read
-                   :navigator/ref    nil
+                   :navigator/ref    @nav/nav-ref
                    :nav/navbar-open? false)
       :http-xhrio {:method          :post
                    :uri             (base-uri "/pages/all")

--- a/client/mobile/src/flybot/client/mobile/core/navigation.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/navigation.cljs
@@ -1,0 +1,23 @@
+(ns flybot.client.mobile.core.navigation
+  (:require [flybot.client.mobile.core.utils :refer [js->cljs]]))
+
+;; To preserve navigation ref when hot reloading
+(defonce nav-ref 
+  (atom nil))
+
+;; To preserve state when hot reloading
+(defonce state (atom nil))
+
+(defn persist-state!
+  "Retains state of the app when hot reloading performed"
+  [state-obj]
+  (js/Promise.
+   (fn [resolve _]
+     (reset! state state-obj)
+     (resolve true))))
+
+(defn nav-params
+  "Given the navigator object ref, returns the current params"
+  [nav-ref]
+  (let [params (when nav-ref (js->cljs (.-params (. nav-ref getCurrentRoute))))]
+    (if (string? params) (uuid params) params)))

--- a/client/mobile/src/flybot/client/mobile/core/utils.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/utils.cljs
@@ -33,9 +33,3 @@
   (if (str/starts-with? path "http")
     path
     (str "https://www.flybot.sg/" path)))
-
-(defn nav-params
-  "Given the navigator object ref, returns the current params"
-  [nav-ref]
-  (let [params (when nav-ref (js->cljs (.-params (. nav-ref getCurrentRoute))))]
-    (if (string? params) (uuid params) params)))

--- a/client/mobile/src/flybot/client/mobile/core/view.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/view.cljs
@@ -2,6 +2,7 @@
   (:require ["@react-navigation/bottom-tabs" :as tab-nav]
             ["@react-navigation/native" :refer [NavigationContainer]]
             ["react-native-vector-icons/Ionicons" :as icon]
+            [flybot.client.mobile.core.navigation :as nav]
             [flybot.client.mobile.core.styles :refer [colors]]
             [flybot.client.mobile.core.utils :refer [cljs->js js->cljs]]
             [flybot.client.mobile.core.view.blog :refer [blog]]
@@ -55,18 +56,12 @@
                     (let [route-name (-> options js->cljs :route :name)]
                       (r/as-element [tab-icon route-name])))}))
 
-(defonce nav-state (atom nil))
-
-(defn- persist-state! [state-obj]
-  (js/Promise.
-   (fn [resolve _]
-     (reset! nav-state state-obj)
-     (resolve true))))
-
 (defn app []
-  [:> NavigationContainer {:ref (fn [el] (rf/dispatch [:evt.nav/set-ref el]))
-                           :on-state-change persist-state!
-                           :initial-state @nav-state}
+  [:> NavigationContainer {:ref (fn [el] 
+                                  (reset! nav/nav-ref el)
+                                  (rf/dispatch [:evt.nav/set-ref el]))
+                           :on-state-change nav/persist-state!
+                           :initial-state @nav/state}
    [:> (.-Navigator bottom-tab-nav) {:screen-options screen-otpions
                                      :initial-route-name "blog"}
     [:> (.-Screen bottom-tab-nav) {:name "home"

--- a/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
@@ -3,12 +3,15 @@
             ["react-native-bouncy-checkbox" :as BouncyCheckbox]
             ["react-native-markdown-package" :as Markdown]
             ["react-native-vector-icons/Ionicons" :as icon]
+            ["react-native" :refer [Alert]]
             [clojure.string :as str]
             [flybot.client.mobile.core.styles :refer [colors]]
-            [flybot.client.mobile.core.utils :refer [js->cljs] :as utils]
+            [flybot.client.mobile.core.utils :refer [cljs->js js->cljs] :as utils]
             [re-frame.core :as rf]
             [reagent.core :as r]
             [reagent.react-native :as rrn]))
+
+
 
 (def markdown (.-default Markdown))
 (def default-icon (.-default icon))
@@ -135,59 +138,83 @@
 ;;---------- Edit Post Screen -----------
 
 (defn post-edit
-  [_]
-  [rrn/scroll-view
-   {:style {:padding 10
-            :border-width 3
-            :border-color (:green colors)}
-    :content-container-style {:gap 10}}
-   [rrn/text
-    {:style {:text-align "center"}}
-    "Side Image source for LIGHT mode:"]
-   [rrn/text-input
-    {:default-value @(rf/subscribe [:subs/pattern '{:form/fields {:post/image-beside {:image/src ?}}}])
-     :on-change-text #(rf/dispatch [:evt.form.image/set-field :image/src %])
-     :style {:border-width 1
-             :padding 10}}]
-   [rrn/text
-    {:style {:text-align "center"}}
-    "Side Image source for DARK mode:"]
-   [rrn/text-input
-    {:default-value @(rf/subscribe [:subs/pattern '{:form/fields {:post/image-beside {:image/src-dark ?}}}])
-     :on-change-text #(rf/dispatch [:evt.form.image/set-field :image/src-dark %])
-     :style {:border-width 1
-             :padding 10}}]
-   [rrn/text
-    {:style {:text-align "center"}}
-    "Side Image description:"]
-   [rrn/text-input
-    {:default-value @(rf/subscribe [:subs/pattern '{:form/fields {:post/image-beside {:image/alt ?}}}])
-     :on-change-text #(rf/dispatch [:evt.form.image/set-field :image/alt %])
-     :style {:border-width 1
-             :padding 10}}]
-   [:> check-box
-    {:text "Show Dates"
-     :is-checked @(rf/subscribe [:subs/pattern '{:form/fields {:post/show-dates? ?}}])
-     :text-style {:text-decoration-line "none"}
-     :on-press #(rf/dispatch [:evt.post.form/set-field :post/show-dates? %])
-     :fill-color (:green colors)
-     :style {:padding 10}}]
-   [:> check-box
-    {:text "Show Authors"
-     :is-checked @(rf/subscribe [:subs/pattern '{:form/fields {:post/show-authors? ?}}])
-     :text-style {:text-decoration-line "none"}
-     :on-press #(rf/dispatch [:evt.post.form/set-field :post/show-authors? %])
-     :fill-color (:green colors)
-     :style {:padding 10}}]
-   [rrn/text
-    {:style {:text-align "center"}}
-    "Post Content in Markdown:"]
-   [rrn/text-input
-    {:default-value @(rf/subscribe [:subs/pattern '{:form/fields {:post/md-content ?}}])
-     :on-change-text #(rf/dispatch [:evt.post.form/set-field :post/md-content %])
-     :multiline true
-     :style {:border-width 1
-             :padding 10}}]])
+  [post-id]
+  [rrn/view
+   [rrn/view
+    {:style {:flex-direction "row"
+             :align-items "center"
+             :justify-content "center"
+             :background-color "white"}}
+    [rrn/button
+     {:title "Submit"
+      :on-press (fn []
+                  (.alert Alert
+                          "Confirmation"
+                          "Are you sure you want to save your changes?"
+                          (cljs->js [{:text "Cancel"}
+                                     {:text "Submit"
+                                      :on-press #(rf/dispatch [:evt.post.form/send-post])}])))}]
+    [rrn/button
+     {:title "Delete"
+      :on-press (fn []
+                  (.alert Alert
+                          "Confirmation"
+                          "Are you sure you want to delete this post?"
+                          (cljs->js [{:text "Cancel"}
+                                     {:text "Delete"
+                                      :on-press #(rf/dispatch [:evt.post/remove-post post-id])}])))}]]
+   [rrn/scroll-view
+    {:style {:padding 10
+             :border-width 3
+             :border-color (:green colors)}
+     :content-container-style {:gap 10}}
+    [rrn/text
+     {:style {:text-align "center"}}
+     "Side Image source for LIGHT mode:"]
+    [rrn/text-input
+     {:default-value @(rf/subscribe [:subs/pattern '{:form/fields {:post/image-beside {:image/src ?}}}])
+      :on-change-text #(rf/dispatch [:evt.form.image/set-field :image/src %])
+      :style {:border-width 1
+              :padding 10}}]
+    [rrn/text
+     {:style {:text-align "center"}}
+     "Side Image source for DARK mode:"]
+    [rrn/text-input
+     {:default-value @(rf/subscribe [:subs/pattern '{:form/fields {:post/image-beside {:image/src-dark ?}}}])
+      :on-change-text #(rf/dispatch [:evt.form.image/set-field :image/src-dark %])
+      :style {:border-width 1
+              :padding 10}}]
+    [rrn/text
+     {:style {:text-align "center"}}
+     "Side Image description:"]
+    [rrn/text-input
+     {:default-value @(rf/subscribe [:subs/pattern '{:form/fields {:post/image-beside {:image/alt ?}}}])
+      :on-change-text #(rf/dispatch [:evt.form.image/set-field :image/alt %])
+      :style {:border-width 1
+              :padding 10}}]
+    [:> check-box
+     {:text "Show Dates"
+      :is-checked @(rf/subscribe [:subs/pattern '{:form/fields {:post/show-dates? ?}}])
+      :text-style {:text-decoration-line "none"}
+      :on-press #(rf/dispatch [:evt.post.form/set-field :post/show-dates? %])
+      :fill-color (:green colors)
+      :style {:padding 10}}]
+    [:> check-box
+     {:text "Show Authors"
+      :is-checked @(rf/subscribe [:subs/pattern '{:form/fields {:post/show-authors? ?}}])
+      :text-style {:text-decoration-line "none"}
+      :on-press #(rf/dispatch [:evt.post.form/set-field :post/show-authors? %])
+      :fill-color (:green colors)
+      :style {:padding 10}}]
+    [rrn/text
+     {:style {:text-align "center"}}
+     "Post Content in Markdown:"]
+    [rrn/text-input
+     {:default-value @(rf/subscribe [:subs/pattern '{:form/fields {:post/md-content ?}}])
+      :on-change-text #(rf/dispatch [:evt.post.form/set-field :post/md-content %])
+      :multiline true
+      :style {:border-width 1
+              :padding 10}}]]])
 
 (defn preview-post-btn
   []

--- a/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
@@ -5,6 +5,7 @@
             ["react-native-vector-icons/Ionicons" :as icon]
             ["react-native" :refer [Alert]]
             [clojure.string :as str]
+            [flybot.client.mobile.core.navigation :as nav]
             [flybot.client.mobile.core.styles :refer [colors]]
             [flybot.client.mobile.core.utils :refer [cljs->js js->cljs] :as utils]
             [re-frame.core :as rf]
@@ -134,7 +135,7 @@
 
 (defn post-read-screen
   []
-  (let [post-id (utils/nav-params @(rf/subscribe [:subs/pattern '{:navigator/ref ?}]))
+  (let [post-id (nav/nav-params @(rf/subscribe [:subs/pattern '{:navigator/ref ?}]))
         post    @(rf/subscribe [:subs/pattern {:app/posts {post-id '?}} [:app/posts post-id]])]
     [:> (.-Screen stack-nav) {:name "post-read"
                               :options {:title "Read Mode"
@@ -149,7 +150,7 @@
 
 (defn post-preview-screen
   []
-  (let [post-id (utils/nav-params @(rf/subscribe [:subs/pattern '{:navigator/ref ?}]))
+  (let [post-id (nav/nav-params @(rf/subscribe [:subs/pattern '{:navigator/ref ?}]))
         post (when (= (uuid "post-in-preview") post-id)
                @(rf/subscribe [:subs/pattern '{:form/fields ?} [:form/fields]]))]
     [:> (.-Screen stack-nav) {:name "post-preview"
@@ -253,7 +254,7 @@
 
 (defn post-edit-screen
   []
-  (let [post-id (utils/nav-params @(rf/subscribe [:subs/pattern '{:navigator/ref ?}]))]
+  (let [post-id (nav/nav-params @(rf/subscribe [:subs/pattern '{:navigator/ref ?}]))]
     [:> (.-Screen stack-nav) {:name "post-edit"
                               :options {:title "Edit Mode"
                                         :animation "slide_from_right"

--- a/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
@@ -70,33 +70,33 @@
   (-> md (str/split #"#" 3) second (str/split #"\n") first str/trim))
 
 (defn post-read
-  [post-id]
-  (let [{:post/keys [md-content image-beside
-                     show-dates? creation-date last-edit-date
-                     show-authors? author last-editor]}
-        @(rf/subscribe [:subs/pattern {:app/posts {post-id '?}} [:app/posts post-id]])]
-    [rrn/scroll-view
-     {:style {:padding 10
-              :border-width 3
-              :border-color (:green colors)}}
-     [rrn/image
-      {:style {:resize-mode "contain"
-               :height 200}
-       :source {:uri (-> image-beside :image/src utils/format-image)}
-       :alt (-> image-beside :image/alt)}]
-     [rrn/view
-      {:style {:padding 10
-               :border-top-width 1
-               :border-top-color (:blue colors)
-               :border-bottom-width 1
-               :border-bottom-color (:blue colors)}}
-      [post-author show-authors? author show-dates? creation-date true]
-      [post-author show-authors? last-editor show-dates? last-edit-date false]]
-     [rrn/view
-      {}
-      [:> markdown
-       {:styles post-styles}
-       md-content]]]))
+  "Given a post, display it as read only.
+   Works for both read and preview."
+  [{:post/keys [md-content image-beside
+                show-dates? creation-date last-edit-date
+                show-authors? author last-editor]}]
+  [rrn/scroll-view
+   {:style {:padding 10
+            :border-width 3
+            :border-color (:green colors)}}
+   [rrn/image
+    {:style {:resize-mode "contain"
+             :height 200}
+     :source {:uri (-> image-beside :image/src utils/format-image)}
+     :alt (-> image-beside :image/alt)}]
+   [rrn/view
+    {:style {:padding 10
+             :border-top-width 1
+             :border-top-color (:blue colors)
+             :border-bottom-width 1
+             :border-bottom-color (:blue colors)}}
+    [post-author show-authors? author show-dates? creation-date true]
+    [post-author show-authors? last-editor show-dates? last-edit-date false]]
+   [rrn/view
+    {}
+    [:> markdown
+     {:styles post-styles}
+     md-content]]])
 
 (defn edit-post-btn
   [post-id]
@@ -107,14 +107,30 @@
 
 (defn post-read-screen
   []
-  (let [post-id (utils/nav-params @(rf/subscribe [:subs/pattern '{:navigator/ref ?}]))]
+  (let [post-id (utils/nav-params @(rf/subscribe [:subs/pattern '{:navigator/ref ?}]))
+        post    @(rf/subscribe [:subs/pattern {:app/posts {post-id '?}} [:app/posts post-id]])]
     [:> (.-Screen stack-nav) {:name "post-read"
                               :options {:title "Read Mode"
                                         :animation "slide_from_right"
                                         :header-right (fn [_]
-                                                        (r/as-element [edit-post-btn post-id]))}
+                                                        (r/as-element [edit-post-btn (:post/id post)]))}
                               :component (r/reactify-component
-                                          (fn [] (post-read post-id)))}]))
+                                          (fn [] (when-not (= (uuid "post-in-preview") post-id)
+                                                   (post-read post))))}]))
+
+;;---------- Preview Post Screen -----------
+
+(defn post-preview-screen
+  []
+  (let [post-id (utils/nav-params @(rf/subscribe [:subs/pattern '{:navigator/ref ?}]))
+        post (when (= (uuid "post-in-preview") post-id)
+               @(rf/subscribe [:subs/pattern '{:form/fields ?} [:form/fields]]))]
+    [:> (.-Screen stack-nav) {:name "post-preview"
+                              :options {:title "Preview"
+                                        :animation "slide_from_right"}
+                              :component (r/reactify-component
+                                          (fn [] (when (= (uuid "post-in-preview") post-id)
+                                                   (post-read post))))}]))
 
 ;;---------- Edit Post Screen -----------
 
@@ -173,12 +189,20 @@
      :style {:border-width 1
              :padding 10}}]])
 
+(defn preview-post-btn
+  []
+  [rrn/button
+   {:title "Preview"
+    :on-press #(rf/dispatch [:evt.nav/navigate "post-preview" "post-in-preview"])}])
+
 (defn post-edit-screen
   []
   (let [post-id (utils/nav-params @(rf/subscribe [:subs/pattern '{:navigator/ref ?}]))]
     [:> (.-Screen stack-nav) {:name "post-edit"
                               :options {:title "Edit Mode"
-                                        :animation "slide_from_right"}
+                                        :animation "slide_from_right"
+                                        :header-right (fn [_]
+                                                        (r/as-element [preview-post-btn]))}
                               :component (r/reactify-component
                                           (fn [] (post-edit post-id)))}]))
 
@@ -244,4 +268,5 @@
   [:> (.-Navigator stack-nav) {:initial-route-name "posts-list"}
    (posts-list-screen)
    (post-read-screen)
-   (post-edit-screen)])
+   (post-edit-screen)
+   (post-preview-screen)])

--- a/ios.cljs.edn
+++ b/ios.cljs.edn
@@ -1,3 +1,4 @@
-^{:react-native :cli}
+^{:react-native :cli
+  :watch-dirs ["client/mobile/src" "client/common/src"]}
 {:main flybot.client.mobile.core
  :closure-defines {flybot.client.common.db.event/BASE-URI "http://localhost:9500"}}


### PR DESCRIPTION
Closes #120 
---

- Add `post-preview` screen
- Add Submit and Delete buttons with error messages and action confirmations
- Navigation ref is persisted no matter what namespaces is reloaded.

## UI

### Confirmation alert

![Screenshot 2023-02-28 at 2 32 12 PM](https://user-images.githubusercontent.com/16139969/221772841-5c738f50-a9f9-412b-8180-2577d9afb77b.png)

### Preview screen

![Screenshot 2023-02-28 at 2 32 35 PM](https://user-images.githubusercontent.com/16139969/221772903-88a060c8-2d22-4ddb-9c66-0672ba5294f8.png)
