### PR TITLE
128 mobile create post

### DIFF
--- a/client/common/src/flybot/client/common/db/event.cljs
+++ b/client/common/src/flybot/client/common/db/event.cljs
@@ -267,7 +267,9 @@
    (if (utils/temporary-id? post-id)
      {:db         (assoc db :form/fields
                          {:post/id   post-id
-                          :post/page (-> db :app/current-view :data :page-name)
+                          :post/page (or (-> db :app/current-view :data :page-name) ;; web page
+                                         :blog ;; mobile screen
+                                         )
                           :post/mode :edit
                           :post/author (-> db :app/user (select-keys [:user/id :user/name]))
                           :post/creation-date (utils/mk-date)})}

--- a/client/common/src/flybot/client/common/db/event.cljs
+++ b/client/common/src/flybot/client/common/db/event.cljs
@@ -14,7 +14,7 @@
   [path]
   (str BASE-URI path))
 
-;; ---------- http ----------
+;; ---------- http success/failure ----------
 
 (rf/reg-event-db
  :fx.http/failure
@@ -50,16 +50,6 @@
                                         :post/last-editor last-editor
                                         :post/last-edit-date (utils/mk-date)))
       :fx [[:fx.log/message ["Got the post " (:post/id post)]]]})))
-
-(rf/reg-event-fx
- :fx.http/send-post-success
- (fn [_ [_ {:keys [posts]}]]
-   (let [{:post/keys [id] :as post} (:new-post posts)]
-     {:fx [[:dispatch [:evt.post/add-post post]]
-           [:dispatch [:evt.post.form/clear-form]]
-           [:dispatch [:evt.error/clear-errors]]
-           [:dispatch [:evt.post/set-modes :read]]
-           [:fx.log/message ["Post " id " sent."]]]})))
 
 (rf/reg-event-fx
  :fx.http/send-page-success

--- a/client/common/src/flybot/client/common/utils.cljs
+++ b/client/common/src/flybot/client/common/utils.cljs
@@ -1,0 +1,8 @@
+(ns flybot.client.common.utils)
+
+(defn sort-posts
+  "Given a seq of `posts`, use the sorting options to order them."
+  [{:sort/keys [type direction]} posts]
+  (if (= :ascending direction)
+    (sort-by type posts)
+    (reverse (sort-by type posts))))

--- a/client/mobile/src/flybot/client/mobile/core/db/event.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/db/event.cljs
@@ -114,3 +114,9 @@
    {:fx [[:dispatch [:evt.post.form/clear-form]]
          [:dispatch [:evt.error/clear-errors]]
          [:dispatch [:evt.nav/navigate "post-read" post-id]]]}))
+
+(rf/reg-event-fx
+ :evt.post.edit/delete
+ (fn [_ [_ post-id]]
+   {:fx [[:dispatch [:evt.post/remove-post post-id]]
+         [:dispatch [:evt.nav/navigate "posts-list"]]]}))

--- a/client/mobile/src/flybot/client/mobile/core/db/event.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/db/event.cljs
@@ -104,6 +104,6 @@
 
 (rf/reg-event-fx
  :evt.post.edit/autofill
- (fn [_ [_ post-id]]
+ (fn [_ [_ screen-name post-id]]
    {:fx [[:dispatch [:evt.post.form/autofill post-id]]
-         [:dispatch [:evt.nav/navigate "post-edit" post-id]]]}))
+         [:dispatch [:evt.nav/navigate screen-name post-id]]]}))

--- a/client/mobile/src/flybot/client/mobile/core/db/event.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/db/event.cljs
@@ -15,7 +15,7 @@
            [:dispatch [:evt.error/clear-errors]]
            [:dispatch [:evt.post/set-modes :read]]
            [:fx.log/message ["Post " id " sent."]]
-           [:dispatch [:evt.nav/navigate "post-read" id]]]})))
+           [:dispatch [:evt.nav/navigate "posts-list"]]]})))
 
 ;; ---------- App ----------
 

--- a/client/mobile/src/flybot/client/mobile/core/db/event.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/db/event.cljs
@@ -107,3 +107,10 @@
  (fn [_ [_ screen-name post-id]]
    {:fx [[:dispatch [:evt.post.form/autofill post-id]]
          [:dispatch [:evt.nav/navigate screen-name post-id]]]}))
+
+(rf/reg-event-fx
+ :evt.post.edit/cancel
+ (fn [_ [_ post-id]]
+   {:fx [[:dispatch [:evt.post.form/clear-form]]
+         [:dispatch [:evt.error/clear-errors]]
+         [:dispatch [:evt.nav/navigate "post-read" post-id]]]}))

--- a/client/mobile/src/flybot/client/mobile/core/styles.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/styles.cljs
@@ -3,5 +3,6 @@
 (def colors
   {:light "#fafafa"
    :dark "#18181b"
+   :light-blue "#f0f9ff"
    :blue "#0ea5e9"
    :green "#22c55e"})

--- a/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
@@ -135,7 +135,7 @@
   [post-id]
   [rrn/button
    {:title "Edit Post"
-    :on-press #(rf/dispatch [:evt.post.edit/autofill post-id])}])
+    :on-press #(rf/dispatch [:evt.post.edit/autofill "post-edit" post-id])}])
 
 (defn post-read-screen
   []
@@ -275,7 +275,7 @@
   (let [{:post/keys [md-content image-beside creation-date author]}
         @(rf/subscribe [:subs/pattern {:app/posts {post-id '?}} [:app/posts post-id]])]
     [rrn/touchable-highlight
-     {:on-press #(rf/dispatch [:evt.post.edit/autofill post-id])
+     {:on-press #(rf/dispatch [:evt.post.edit/autofill "post-read" post-id])
       :underlay-color (:blue colors)}
      [rrn/view
       {:style {:flex-direction "row"

--- a/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
@@ -256,12 +256,24 @@
    {:title "Preview"
     :on-press #(rf/dispatch [:evt.nav/navigate "post-preview" "post-in-preview"])}])
 
+(defn cancel-edit-btn
+  [post-id]
+  [rrn/button
+   {:title "Cancel"
+    :on-press (fn []
+                (rn-alert "Confirmation" "Are you sure you want to go back? Your changes won't be saved."
+                          [{:text "Keep Editing"}
+                           {:text "Back to Read Mode"
+                            :on-press #(rf/dispatch [:evt.post.edit/cancel post-id])}]))}])
+
 (defn post-edit-screen
   []
   (let [post-id (nav/nav-params @(rf/subscribe [:subs/pattern '{:navigator/ref ?}]))]
     [:> (.-Screen stack-nav) {:name "post-edit"
                               :options {:title "Edit Mode"
                                         :animation "slide_from_right"
+                                        :header-left (fn [_]
+                                                       (r/as-element [cancel-edit-btn post-id]))
                                         :header-right (fn [_]
                                                         (r/as-element [preview-post-btn]))}
                               :component (r/reactify-component

--- a/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
@@ -188,7 +188,7 @@
                  (rn-alert "Confirmation" "Are you sure you want to delete this post?"
                            [{:text "Cancel"}
                             {:text "Delete"
-                             :on-press #(rf/dispatch [:evt.post/remove-post post-id])}]))}]])
+                             :on-press #(rf/dispatch [:evt.post.edit/delete post-id])}]))}]])
 
 (defn edit-post-form
   []

--- a/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
@@ -6,6 +6,7 @@
             ["react-native" :refer [Alert]]
             [clojure.string :as str]
             [flybot.common.utils :refer [temporary-id?]]
+            [flybot.client.common.utils :refer [sort-posts]]
             [flybot.client.mobile.core.navigation :as nav]
             [flybot.client.mobile.core.styles :refer [colors]]
             [flybot.client.mobile.core.utils :refer [cljs->js js->cljs] :as utils]
@@ -336,7 +337,9 @@
 (defn posts-list
   []
   (let [new-post {:post/id "new-post-temp-id"}
-        posts    @(rf/subscribe [:subs.post/posts :blog])]
+        posts    (->> @(rf/subscribe [:subs.post/posts :blog])
+                      (sort-posts #:sort{:type :post/creation-date
+                                         :direction :descending}))]
     [rrn/view
      {:style {:background-color (:light colors)
               :flex 1

--- a/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
@@ -130,8 +130,7 @@
   [post-id]
   [rrn/button
    {:title "Edit Post"
-    :on-press #(do (rf/dispatch [:evt.nav/navigate "post-edit" post-id])
-                   (rf/dispatch [:evt.post.form/autofill post-id]))}])
+    :on-press #(rf/dispatch [:evt.post.edit/autofill post-id])}])
 
 (defn post-read-screen
   []
@@ -175,7 +174,7 @@
                  (rn-alert "Confirmation" "Are you sure you want to save your changes?"
                            [{:text "Cancel"}
                             {:text "Submit"
-                             :on-press #(rf/dispatch [:evt.post.form/send-post])}]))}]
+                             :on-press #(rf/dispatch [:evt.post.form/send-post post-id])}]))}]
    [rrn/button
     {:title "Delete"
      :on-press (fn []
@@ -218,6 +217,7 @@
    [:> check-box
     {:text "Show Dates"
      :is-checked @(rf/subscribe [:subs/pattern '{:form/fields {:post/show-dates? ?}}])
+     :disableBuiltInState true
      :text-style {:text-decoration-line "none"}
      :on-press #(rf/dispatch [:evt.post.form/set-field :post/show-dates? %])
      :fill-color (:green colors)
@@ -225,6 +225,7 @@
    [:> check-box
     {:text "Show Authors"
      :is-checked @(rf/subscribe [:subs/pattern '{:form/fields {:post/show-authors? ?}}])
+     :disableBuiltInState true
      :text-style {:text-decoration-line "none"}
      :on-press #(rf/dispatch [:evt.post.form/set-field :post/show-authors? %])
      :fill-color (:green colors)
@@ -271,8 +272,7 @@
   (let [{:post/keys [id md-content image-beside creation-date author]}
         @(rf/subscribe [:subs/pattern {:app/posts {post-id '?}} [:app/posts post-id]])]
     [rrn/touchable-highlight
-     {:on-press #(do (rf/dispatch [:evt.nav/navigate "post-read" id])
-                     (rf/dispatch [:evt.post.form/autofill id]))
+     {:on-press #(rf/dispatch [:evt.post.edit/autofill id])
       :underlay-color (:blue colors)}
      [rrn/view
       {:style {:flex-direction "row"

--- a/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
@@ -111,7 +111,8 @@
    (when image-beside
      [rrn/image
       {:style {:resize-mode "contain"
-                :height 200}
+               :height 200
+               :margin 10}
        :source {:uri (-> image-beside :image/src utils/format-image)}
        :alt (-> image-beside :image/alt)}])
    [rrn/view
@@ -287,7 +288,9 @@
   (let [{:post/keys [md-content image-beside creation-date author]}
         @(rf/subscribe [:subs/pattern {:app/posts {post-id '?}} [:app/posts post-id]])]
     [rrn/touchable-highlight
-     {:on-press #(rf/dispatch [:evt.post.edit/autofill "post-read" post-id])
+     {:on-press #(if (temporary-id? post-id)
+                   (rf/dispatch [:evt.post.edit/autofill "post-edit" post-id])
+                   (rf/dispatch [:evt.post.edit/autofill "post-read" post-id]))
       :underlay-color (:blue colors)}
      [rrn/view
       {:style {:flex-direction "row"

--- a/client/web/src/flybot/client/web/core/db/event.cljs
+++ b/client/web/src/flybot/client/web/core/db/event.cljs
@@ -6,6 +6,18 @@
             [re-frame.core :as rf]
             [reitit.frontend.easy :as rfe]))
 
+;; ---------- http success/failure ----------
+
+(rf/reg-event-fx
+ :fx.http/send-post-success
+ (fn [_ [_ {:keys [posts]}]]
+   (let [{:post/keys [id] :as post} (:new-post posts)]
+     {:fx [[:dispatch [:evt.post/add-post post]]
+           [:dispatch [:evt.post.form/clear-form]]
+           [:dispatch [:evt.error/clear-errors]]
+           [:dispatch [:evt.post/set-modes :read]]
+           [:fx.log/message ["Post " id " sent."]]]})))
+
 ;; ---------- App ----------
 
 ;; Initialization

--- a/client/web/src/flybot/client/web/core/dom/page.cljs
+++ b/client/web/src/flybot/client/web/core/dom/page.cljs
@@ -1,14 +1,9 @@
 (ns flybot.client.web.core.dom.page
-  (:require [flybot.client.web.core.dom.hiccup :as h]
+  (:require [flybot.client.common.utils :as utils]
+            [flybot.client.web.core.dom.hiccup :as h]
             [flybot.client.web.core.dom.page.header :refer [page-header]]
             [flybot.client.web.core.dom.page.post :refer [page-post]]
             [re-frame.core :as rf]))
-
-(defn sort-posts
-  [{:sort/keys [type direction]} posts]
-  (if (= :ascending direction)
-    (sort-by type posts)
-    (reverse (sort-by type posts))))
 
 (defn page
   "Given the `page-name`, returns the page content."
@@ -18,7 +13,7 @@
                                        [:app/pages page-name :page/sorting-method]])
         ordered-posts (->> @(rf/subscribe [:subs.post/posts page-name])
                            (map #(assoc % :post/hiccup-content (h/md->hiccup (:post/md-content %))))
-                           (sort-posts sorting-method))
+                           (utils/sort-posts sorting-method))
         new-post      {:post/id "new-post-temp-id"}
         posts         (conj ordered-posts new-post)]
     [:section.container


### PR DESCRIPTION
Closes #128
---

- Fix some navigation issues after post submitted
- Add new post option in the `posts-list` screen
- Creating a new post use the same screen as for editing a post: `post-edit`
- Overwrite default back button implementation for the `post-edit` screen (prompt user if he is sure to discard changes)
- After post submission, navigate to `post-lists` screen

### posts-list screen

![Screenshot 2023-03-09 at 4 43 22 PM](https://user-images.githubusercontent.com/16139969/223967841-635c3875-d586-4784-b060-27cf8eec3717.png)
