### PR TITLE
130 mobile user mode

### DIFF
--- a/client/mobile/src/flybot/client/mobile/core/db/event.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/db/event.cljs
@@ -117,3 +117,12 @@
  (fn [_ [_ post-id]]
    {:fx [[:dispatch [:evt.post/remove-post post-id]]
          [:dispatch [:evt.nav/navigate "posts-list"]]]}))
+
+;; ---------- Login/Logout ----------
+
+(rf/reg-event-fx
+ :evt.login/link-url-listener
+ (fn [_ [_ cookie]]
+   {:fx [[:dispatch [:evt.cookie/set "ring-session" cookie]]
+         [:dispatch [:evt.app/initialize]]
+         [:dispatch [:evt.nav/navigate "blog"]]]}))

--- a/client/mobile/src/flybot/client/mobile/core/db/event.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/db/event.cljs
@@ -22,53 +22,48 @@
 
 (rf/reg-event-fx
  :evt.app/initialize
- (fn [{:keys [db local-store-theme]} _]
-   (let [app-theme (or local-store-theme :dark)]
-     {:db         (assoc
-                   db
-                   :app/theme        app-theme
-                   :user/mode        :reader
-                   :admin/mode       :read
-                   :navigator/ref    @nav/nav-ref
-                   :nav/navbar-open? false)
-      :http-xhrio {:method          :post
-                   :uri             (base-uri "/pages/all")
-                   :headers {:cookie (:user/cookie db)}
-                   :params {:pages
-                            {(list :all :with [])
-                             [{:page/name '?
-                               :page/sorting-method {:sort/type '?
-                                                     :sort/direction '?}}]}
-                            :posts
-                            {(list :all :with [])
-                             [{:post/id '?
-                               :post/page '?
-                               :post/css-class '?
-                               :post/creation-date '?
-                               :post/last-edit-date '?
-                               :post/author {:user/id '?
-                                             :user/name '?}
-                               :post/last-editor {:user/id '?
-                                                  :user/name '?}
-                               :post/show-authors? '?
-                               :post/show-dates? '?
-                               :post/md-content '?
-                               :post/image-beside {:image/src '?
-                                                   :image/src-dark '?
-                                                   :image/alt '?}}]}
-                            :users
-                            {:auth
-                             {(list :logged :with [])
-                              {:user/id '?
-                               :user/email '?
-                               :user/name '?
-                               :user/picture '?
-                               :user/roles [{:role/name '?
-                                             :role/date-granted '?}]}}}}
-                   :format          (edn-request-format {:keywords? true})
-                   :response-format (edn-response-format {:keywords? true})
-                   :on-success      [:fx.http/all-success]
-                   :on-failure      [:fx.http/failure]}})))
+ (fn [{:keys [db]} _]
+   {:db         (assoc
+                 db
+                 :navigator/ref @nav/nav-ref)
+    :http-xhrio {:method          :post
+                 :uri             (base-uri "/pages/all")
+                 :headers {:cookie (:user/cookie db)}
+                 :params {:pages
+                          {(list :all :with [])
+                           [{:page/name '?
+                             :page/sorting-method {:sort/type '?
+                                                   :sort/direction '?}}]}
+                          :posts
+                          {(list :all :with [])
+                           [{:post/id '?
+                             :post/page '?
+                             :post/css-class '?
+                             :post/creation-date '?
+                             :post/last-edit-date '?
+                             :post/author {:user/id '?
+                                           :user/name '?}
+                             :post/last-editor {:user/id '?
+                                                :user/name '?}
+                             :post/show-authors? '?
+                             :post/show-dates? '?
+                             :post/md-content '?
+                             :post/image-beside {:image/src '?
+                                                 :image/src-dark '?
+                                                 :image/alt '?}}]}
+                          :users
+                          {:auth
+                           {(list :logged :with [])
+                            {:user/id '?
+                             :user/email '?
+                             :user/name '?
+                             :user/picture '?
+                             :user/roles [{:role/name '?
+                                           :role/date-granted '?}]}}}}
+                 :format          (edn-request-format {:keywords? true})
+                 :response-format (edn-response-format {:keywords? true})
+                 :on-success      [:fx.http/all-success]
+                 :on-failure      [:fx.http/failure]}}))
 
 (rf/reg-event-fx
  :evt.app/initialize-with-cookie

--- a/client/mobile/src/flybot/client/mobile/core/styles.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/styles.cljs
@@ -5,4 +5,5 @@
    :dark "#18181b"
    :light-blue "#f0f9ff"
    :blue "#0ea5e9"
-   :green "#22c55e"})
+   :green "#22c55e"
+   :grey "grey"})

--- a/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
@@ -135,9 +135,19 @@
 
 (defn edit-post-btn
   [post-id]
-  [rrn/button
-   {:title "Edit Post"
-    :on-press #(rf/dispatch [:evt.post.edit/autofill "post-edit" post-id])}])
+  (let [user-id @(rf/subscribe [:subs/pattern {:app/user {:user/id '?}}])]
+    (if user-id
+      [rrn/button
+       {:title "Edit Post"
+        :on-press #(rf/dispatch [:evt.post.edit/autofill "post-edit" post-id])}]
+      [rrn/button
+       {:title "Edit Post"
+        :color "grey"
+        :on-press (fn []
+                    (rn-alert "Warning" "You need to login for editing."
+                              [{:text "Login"
+                                :on-press #(rf/dispatch [:evt.nav/navigate "login" post-id])}
+                               {:text "Cancel"}]))}])))
 
 (defn post-read-screen
   []
@@ -366,8 +376,9 @@
 
 (defn blog
   []
-  [:> (.-Navigator stack-nav) {:initial-route-name "posts-list"}
-   (posts-list-screen)
-   (post-read-screen)
-   (post-edit-screen)
-   (post-preview-screen)])
+  (let [user-id @(rf/subscribe [:subs/pattern {:app/user {:user/id '?}}])]
+    [:> (.-Navigator stack-nav) {:initial-route-name "posts-list"}
+     (posts-list-screen)
+     (post-read-screen)
+     (when user-id (post-edit-screen))
+     (when user-id (post-preview-screen))]))

--- a/client/mobile/src/flybot/client/mobile/core/view/login.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/view/login.cljs
@@ -11,8 +11,7 @@
                    (fn [url]
                      (let [cookie (-> url js->cljs :url (str/split "?") second)] 
                        (when cookie
-                         (rf/dispatch [:evt.cookie/set "ring-session" cookie])
-                         (rf/dispatch [:evt.app/initialize])))))
+                         (rf/dispatch [:evt.login/link-url-listener cookie])))))
 
 (defn login
   []


### PR DESCRIPTION
Closes #130
---

- When user not logged in, grey out the post creation/editing options and when clicked prompt login tab
- After login/logout, redirect the user to the last blog screen (where he last navigated)
- Change icon in the bottom tab bar if user is logged in/out

### Logged out posts list

![Screenshot 2023-03-10 at 3 21 29 PM](https://user-images.githubusercontent.com/16139969/224249922-b0520c0c-1d7a-45b5-9b4c-e0b8c64721a7.png)

### Logged in posts list

![Screenshot 2023-03-10 at 3 21 10 PM](https://user-images.githubusercontent.com/16139969/224249990-a7c71b8e-8628-4cc9-8aa2-a57a7f5e6d1b.png)

### Clicking Edit post while logged out prompt login alert

![Screenshot 2023-03-10 at 3 23 25 PM](https://user-images.githubusercontent.com/16139969/224250279-bb83153b-96e8-4012-860b-d485c39c3cc0.png)
