### PR TITLE
138 admin and oauth2 config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,8 @@ build
 .nrepl-port
 
 ## config
-OAUTH2.edn
-admin.edn
+##oauth2.edn
+##admin.edn
 
 ## build
 target

--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,8 @@ build
 .nrepl-port
 
 ## config
-##oauth2.edn
-##admin.edn
+oauth2.edn
+admin.edn
 
 ## build
 target

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Jack-in `deps+figwheel`:
 
 If you use Emacs (or Doom Emacs, or Spacemacs) with CIDER, the CIDER jack-in is done in 3 steps:
 
-1. `C-u M-x cider-jack-in-clj&cljs`
+1. `C-u M-x cider-jack-in-clj&cljs` or `C-u M-x cider-jack-in-cljs`
 2. By default, emacs use the `cider/nrepl` alias such as in `-M:cider/nrepl`. You need to keep this alias at the end such as `-M:jvm-base:client:web/dev:cider/nrepl`
 3. Select ClojureScript REPL type: `figwheel-main`
 4. Select figwheel-main build: `dev`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,34 @@
 # flybot.sg
 Full stack implementation of flybot.sg website
 
+## Config files
+
+In the `config` directory, you can see 3 config files:
+
+1) `system.edn`
+
+It ontains the different environment properties that are used to setup the systems (dev, test, figwheel, prod).
+
+2) `oauth2.edn`
+
+The oauth2 credentials to allow your application to access google services.
+
+You need to provide the google id and secret that allow the oauth client to communicate with the oauth server.
+
+You can read more about it [here](https://github.com/skydread1/reitit-oauth2#readme)
+
+_Note_: not providing the creds will prevent you from login/logout
+
+_Note 2_: the `redirect-uri` is specified in the `system.edn` because it depends on the environment.
+
+3) `admin.edn`
+
+It contains the admin user, who is loaded to the DB at system start, so you can dev/test the admin panel features. You need to use a google account that is allowed by your `Location` (i.e. company account)
+
+_Note_: your google account needs to belong to the google application linked to the app.
+
+_Note 2_: not providing your acc id will prevent you from doing admin tasks.
+
 ## frontend : WEB
 
 ### DEV

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Jack-in `deps+figwheel`:
 
 If you use Emacs (or Doom Emacs, or Spacemacs) with CIDER, the CIDER jack-in is done in 3 steps:
 
-1. `C-u M-x cider-jack-in-cljs`
-2. A long command will appear at the bottom, ending with something like `-M:cider/nrepl`. Change this ending to `-M:jvm-base:client:web/dev:cider/nrepl`
+1. `C-u M-x cider-jack-in-clj&cljs`
+2. By default, emacs use the `cider/nrepl` alias such as in `-M:cider/nrepl`. You need to keep this alias at the end such as `-M:jvm-base:client:web/dev:cider/nrepl`
 3. Select ClojureScript REPL type: `figwheel-main`
 4. Select figwheel-main build: `dev`
 

--- a/config/admin.edn
+++ b/config/admin.edn
@@ -1,0 +1,3 @@
+#:user{:id "google-personal-acc-id" ;; can be fetched via google api
+       :email "bob@company.com"
+       :name "Bob Smith"}

--- a/config/oauth2.edn
+++ b/config/oauth2.edn
@@ -1,0 +1,3 @@
+{:google-creds {:client-id     "secret" ;; use the google id
+                :client-secret "secret" ;; use the google secret
+                }}


### PR DESCRIPTION
Closes #138
---

- add default `admin.edn` and `oauth2.edn` so dev system does not throw an error on start
- add instructions on readme on what config to provide to these config files
- updates emacs instructions on readme