### PR TITLE
Make assets, js and css paths relative

### DIFF
--- a/client/mobile/src/flybot/client/mobile/core/utils.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/utils.cljs
@@ -28,7 +28,7 @@
 (defn format-image
   "Relative path for image does not seem to be working, so
    - if the path is aboslute, return it.
-   - if path is relative (such as 'assets/logo.png'), turn it into abasolute path."
+   - if path is relative (such as '/assets/logo.png'), turn it into abasolute path."
   [path]
   (if (str/starts-with? path "http")
     path

--- a/client/web/src/flybot/client/web/core/dom/admin_panel.cljs
+++ b/client/web/src/flybot/client/web/core/dom/admin_panel.cljs
@@ -43,7 +43,7 @@
 (defn  admin-section
   []
   (when (and (= :editor @(rf/subscribe [:subs/pattern '{:user/mode ?x}]))
-             (some #{:admin} (->> @(rf/subscribe [:subs/pattern '{:app/user {:user/roles [{:role/name ?x}]}}])
+             (some #{:admin} (->> @(rf/subscribe [:subs/pattern '{:app/user {:user/roles [{:role/name ?} ?x]}}])
                                   (map :role/name))))
     [:section.container.admin
      [:h1 "Admin"]

--- a/client/web/src/flybot/client/web/core/dom/header.cljs
+++ b/client/web/src/flybot/client/web/core/dom/header.cljs
@@ -45,7 +45,7 @@
     [:div
      [:img.flybotlogo
       {:alt "Flybot logo"
-       :src "assets/flybot-logo.png"}]]
+       :src "/assets/flybot-logo.png"}]]
     [svg/theme-logo]
     (when @(rf/subscribe [:subs/pattern '{:app/user ?x}])
       [svg/user-mode-logo])

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -33,11 +33,11 @@
         <meta name="twitter:image" content="http://www.flybot.sg/static/media/flybot-logo.5c92e3d50082cfa03409.png">
 
         <!-- this refers to resources/public/css/style.css -->
-        <link href="css/style.css" rel="stylesheet" type="text/css">
+        <link href="/css/style.css" rel="stylesheet" type="text/css">
     </head>
     <body>
         <div id="app"></div>
-        <!-- use cljs-out/dev-main.js for development -->
-        <script src="main.js" type="application/javascript"></script>
+        <!-- use /cljs-out/dev-main.js for development -->
+        <script src="/main.js" type="application/javascript"></script>
     </body>
 </html>

--- a/server/src/flybot/server/core/init_data.clj
+++ b/server/src/flybot/server/core/init_data.clj
@@ -29,8 +29,8 @@
           :css-class "company"
           :creation-date (u/mk-date)
           :md-content (slurp-md "about" "company.md")
-          :image-beside #:image{:src "assets/flybot-logo.png"
-                                :src-dark "assets/flybot-logo.png"
+          :image-beside #:image{:src "/assets/flybot-logo.png"
+                                :src-dark "/assets/flybot-logo.png"
                                 :alt "Flybot Logo"}}
    #:post{:id (u/mk-uuid)
           :page :about
@@ -71,8 +71,8 @@
           :author (first users)
           :last-editor (first users)
           :md-content (slurp-md "blog" "welcome.md")
-          :image-beside #:image{:src "assets/flybot-logo.png"
-                                :src-dark "assets/flybot-logo.png"
+          :image-beside #:image{:src "/assets/flybot-logo.png"
+                                :src-dark "/assets/flybot-logo.png"
                                 :alt "Flybot Logo"}}
    #:post{:id (u/mk-uuid)
           :page :blog
@@ -94,32 +94,32 @@
           :css-class "clojure"
           :creation-date (u/mk-date)
           :md-content (slurp-md "home" "clojure.md")
-          :image-beside #:image{:src "assets/clojure-logo.svg"
-                                :src-dark "assets/clojure-logo-dark-mode.svg"
+          :image-beside #:image{:src "/assets/clojure-logo.svg"
+                                :src-dark "/assets/clojure-logo-dark-mode.svg"
                                 :alt "Clojure Logo"}}
    #:post{:id (u/mk-uuid)
           :page :home
           :css-class "paradigms"
           :creation-date (u/mk-date)
           :md-content (slurp-md "home" "paradigms.md")
-          :image-beside #:image{:src "assets/lambda-logo.svg"
-                                :src-dark "assets/lambda-logo-dark-mode.svg"
+          :image-beside #:image{:src "/assets/lambda-logo.svg"
+                                :src-dark "/assets/lambda-logo-dark-mode.svg"
                                 :alt "Lambda Logo"}}
    #:post{:id (u/mk-uuid)
           :page :home
           :css-class "golden-island"
           :creation-date (u/mk-date)
           :md-content (slurp-md "home" "golden-island.md")
-          :image-beside #:image{:src "assets/4suits.svg"
-                                :src-dark "assets/4suits-dark-mode.svg"
+          :image-beside #:image{:src "/assets/4suits.svg"
+                                :src-dark "/assets/4suits-dark-mode.svg"
                                 :alt "4 suits of a deck"}}
    #:post{:id (u/mk-uuid)
           :page :home
           :css-class "magic"
           :creation-date (u/mk-date)
           :md-content (slurp-md "home" "magic.md")
-          :image-beside #:image{:src "assets/binary.svg"
-                                :src-dark "assets/binary-dark-mode.svg"
+          :image-beside #:image{:src "/assets/binary.svg"
+                                :src-dark "/assets/binary-dark-mode.svg"
                                 :alt "Love word written in base 2"}}])
 
 (def posts

--- a/server/src/flybot/server/core/init_data/md_content/about/team.md
+++ b/server/src/flybot/server/core/init_data/md_content/about/team.md
@@ -3,16 +3,16 @@
 <div>
 ## Luo Tian
 ### CEO
-[![Github Logo](assets/github-mark-logo.png "github" srcdark="assets/github-mark-logo-dark-mode.png")](https://github.com/robertluo)
+[![Github Logo](/assets/github-mark-logo.png "github" srcdark="/assets/github-mark-logo-dark-mode.png")](https://github.com/robertluo)
 </div>
 <div>
 ## Loic Blanchard
 ### Software Engineer
-[![Github Logo](assets/github-mark-logo.png "github" srcdark="assets/github-mark-logo-dark-mode.png")](https://github.com/skydread1)
+[![Github Logo](/assets/github-mark-logo.png "github" srcdark="/assets/github-mark-logo-dark-mode.png")](https://github.com/skydread1)
 </div>
 <div>
 ## Melinda Zheng
 ### HR Manager
-[![Linkedin Logo](assets/linkedin-logo.png)](https://www.linkedin.com/company/86215279/)
+[![Linkedin Logo](/assets/linkedin-logo.png)](https://www.linkedin.com/company/86215279/)
 </div>
 </div>


### PR DESCRIPTION
Closes #148 

`assets`, `main.js` and `css/style.css` are now absolute to prevent nested routes issues