### PR TITLE
Enable some CI steps for fork's PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches-ignore:
       - master
+  pull_request:
+    types: [opened, synchronize, ready_for_review, review_requested, closed]
+  # Allows the CI to use the secrets to push to ECR when a fork is merged.
+  # You can see the if statement in the ECR step. 
+  pull_request_target:
+    types: [closed]
 
 env:
   OAUTH2: ""
@@ -32,6 +38,7 @@ jobs:
         run: clojure -T:build js-bundle
 
       - name: Build image and push to ECR
+        if: github.event.pull_request.merged == true
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Closes #153
---

- fork's PR triggers tests steps in workflow.
- pushing to ECR is only done when a branch (from fork or internal) is merged.