### PR TITLE
Fix nil-related error in has-valid-h1-title?-test

### DIFF
--- a/client/web/test/flybot/client/web/test_runner.cljs
+++ b/client/web/test/flybot/client/web/test_runner.cljs
@@ -4,7 +4,8 @@
     ;; require all the namespaces that have tests in them
     [flybot.client.web.core.db-test]
     [flybot.client.web.core.dom.common.link-test]
-    [flybot.client.web.core.dom.page.post-test]))
+    [flybot.client.web.core.dom.page.post-test]
+    [flybot.common.validation.markdown-test]))
 
 (defn -main [& args]
   ;; this needs to be the last statement in the main function so that it can

--- a/common/src/flybot/common/validation/markdown.cljc
+++ b/common/src/flybot/common/validation/markdown.cljc
@@ -2,8 +2,8 @@
   (:require [markdown-to-hiccup.core :as mth]))
 
 (defn has-valid-h1-title?
-  "Checks that the given Markdown content contains exactly one H1 heading at
-  the start."
+  "Returns true if the given Markdown content contains exactly one H1 heading
+  at the start, otherwise returns false."
   [md-content]
   (let [starts-with-h1? (fn [[div _ [element]]]
                           (and (= :div div) (= :h1 element)))
@@ -11,7 +11,7 @@
                                    (empty? (mth/hiccup-in hiccup :h1 1)))
         contains-valid-h1? (every-pred starts-with-h1?
                                        contains-exactly-one-h1?)]
-    (-> md-content
-        mth/md->hiccup
-        mth/component
-        contains-valid-h1?)))
+    (boolean (some-> md-content
+                     mth/md->hiccup
+                     mth/component
+                     contains-valid-h1?))))

--- a/common/test/flybot/common/validation/markdown_test.cljc
+++ b/common/test/flybot/common/validation/markdown_test.cljc
@@ -1,34 +1,15 @@
 (ns flybot.common.validation.markdown-test
-  (:require [flybot.common.test-sample-data :as s]
-            [flybot.common.validation.markdown :as md]
-            #?(:clj [clojure.test :refer [deftest is are]]
-               :cljs [cljs.test :refer [deftest is are]])))
+  (:require [clojure.test :refer [deftest is]]
+            [flybot.common.validation.markdown :as md]))
 
 (deftest has-valid-h1-title?-test
-  (let [test-posts (concat
-                    [s/post-1 s/post-2]
-                    [s/post-3]
-                    [(assoc s/post-3
-                            :post/md-content
-                            "# [H1 link heading](https://www.flybot.sg)")]
-                    [(dissoc s/post-3 :post/md-content)]
-                    (map #(assoc s/post-3 :post/md-content %)
-                         [nil
-                          "No headings"
-                          "## No H1 headings\n\n### anywhere"
-                          "Some content before\n# First H1 heading"
-                          "# Multiple\n\n# H1 headings"]))]
-    (are [string expected] (= expected (md/has-valid-h1-title? string))
-      nil false
-      "#No space" true
-      "# One space\n" true
-      "# [H1 link heading](https://www.flybot.sg)" true
-      "No headings" false
-      "## No H1 headings\n\n### anywhere" false
-      "Some content before\n# First H1 heading" false
-      "# Multiple\n\n# H1 headings" false)
-    (is (= (concat (repeat 4 true) (repeat 6 false))
-           (map #(-> %
-                     :post/md-content
-                     md/has-valid-h1-title?)
-                test-posts)))))
+  (is (true? (md/has-valid-h1-title? "#No space")))
+  (is (true? (md/has-valid-h1-title? "# One space\n")))
+  (is (true? (md/has-valid-h1-title?
+              "# [H1 link heading](https://www.flybot.sg)")))
+  (is (false? (md/has-valid-h1-title? nil)))
+  (is (false? (md/has-valid-h1-title? "No headings")))
+  (is (false? (md/has-valid-h1-title? "## No H1 headings\n\n### anywhere")))
+  (is (false? (md/has-valid-h1-title? "# Multiple\n\n# H1 headings")))
+  (is (false? (md/has-valid-h1-title?
+               "Some content before\n# First H1 heading"))))

--- a/common/test/flybot/common/validation/markdown_test.cljc
+++ b/common/test/flybot/common/validation/markdown_test.cljc
@@ -1,15 +1,27 @@
 (ns flybot.common.validation.markdown-test
-  (:require [clojure.test :refer [deftest is]]
-            [flybot.common.validation.markdown :as md]))
+  (:require [clojure.test :refer [deftest is testing]]
+            [flybot.common.validation.markdown :as sut]))
 
 (deftest has-valid-h1-title?-test
-  (is (true? (md/has-valid-h1-title? "#No space")))
-  (is (true? (md/has-valid-h1-title? "# One space\n")))
-  (is (true? (md/has-valid-h1-title?
-              "# [H1 link heading](https://www.flybot.sg)")))
-  (is (false? (md/has-valid-h1-title? nil)))
-  (is (false? (md/has-valid-h1-title? "No headings")))
-  (is (false? (md/has-valid-h1-title? "## No H1 headings\n\n### anywhere")))
-  (is (false? (md/has-valid-h1-title? "# Multiple\n\n# H1 headings")))
-  (is (false? (md/has-valid-h1-title?
-               "Some content before\n# First H1 heading"))))
+  (testing "Markdown string H1 title validation"
+    (testing "Valid: one H1 heading at start, none elsewhere"
+      (is (true? (sut/has-valid-h1-title? "#No space")))
+      (is (true? (sut/has-valid-h1-title?
+                  "# One space\nAnd then some content.")))
+      (is (true? (sut/has-valid-h1-title?
+                  "# [H1 link heading](https://www.flybot.sg)"))))
+
+    (testing "Invalid: nil"
+      (is (false? (sut/has-valid-h1-title? nil))))
+
+    (testing "Invalid: no H1 headings anywhere"
+      (is (false? (sut/has-valid-h1-title? "No headings")))
+      (is (false? (sut/has-valid-h1-title?
+                   "## This is H2\n\n### And this is H3"))))
+
+    (testing "Invalid: multiple H1 headings"
+      (is (false? (sut/has-valid-h1-title? "# Multiple\n\n# H1 headings"))))
+
+    (testing "Invalid: H1 heading not at start"
+      (is (false? (sut/has-valid-h1-title?
+                   "Some content before\n# First H1 heading"))))))

--- a/common/test/flybot/common/validation/markdown_test.cljc
+++ b/common/test/flybot/common/validation/markdown_test.cljc
@@ -19,7 +19,7 @@
                           "Some content before\n# First H1 heading"
                           "# Multiple\n\n# H1 headings"]))]
     (are [string expected] (= expected (md/has-valid-h1-title? string))
-      nil nil
+      nil false
       "#No space" true
       "# One space\n" true
       "# [H1 link heading](https://www.flybot.sg)" true
@@ -27,7 +27,7 @@
       "## No H1 headings\n\n### anywhere" false
       "Some content before\n# First H1 heading" false
       "# Multiple\n\n# H1 headings" false)
-    (is (= (concat (repeat 4 true) (repeat 2 nil) (repeat 4 false))
+    (is (= (concat (repeat 4 true) (repeat 6 false))
            (map #(-> %
                      :post/md-content
                      md/has-valid-h1-title?)


### PR DESCRIPTION
## Closes #158

- [x] `has-valid-h1-title?-test` now requires `(has-valid-h1-title? nil)` to return `false` (to follow Clojure's convention to have predicate functions only return booleans).
- [x] `has-valid-h1-title?` now handles `nil` correctly.
        (It still throws an error when the argument is neither `nil` nor a string.)

