### PR TITLE
Remove closed type in pull_request CI event

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
     branches-ignore:
       - master
   pull_request:
-    types: [opened, ready_for_review, review_requested, closed]
+    types: [opened, ready_for_review, review_requested]
   # Allows the CI to use the secrets to push to ECR when a fork is merged.
   # You can see the if statement in the ECR step. 
   pull_request_target:


### PR DESCRIPTION
Closes #160
---
- event `pull_request_target` with type `closed` is now the only event triggered on PR merging and the secrets can be used for both fork on internal PRs