### PR TITLE
Allow email addresses with underscores to log in

### DIFF
--- a/common/src/flybot/common/validation.cljc
+++ b/common/src/flybot/common/validation.cljc
@@ -28,7 +28,7 @@
                           [:role/date-granted inst?]]]]])
 
 (def user-email-schema
-  [:re #"^([a-zA-Z0-9]+)([\.{1}])?([a-zA-Z0-9]+)@basecity.com$"])
+  [:re #"^([a-zA-Z0-9_-]+)([\.])?([a-zA-Z0-9_-]+)@basecity\.com$"])
 
 (def post-schema
   [:map {:closed true}


### PR DESCRIPTION
## Closes #162

Email addresses with underscores (e.g., employee_no_5@flybot_domain.com) should now pass the email validation and log in successfully.

FIXME: There may be other email patterns that cause login errors and are unaccounted for.