### PR TITLE
Redirect post URLs with old or wrong titles

### DIFF
--- a/client/common/src/flybot/client/common/db/event.cljs
+++ b/client/common/src/flybot/client/common/db/event.cljs
@@ -4,10 +4,7 @@
             [ajax.edn :refer [edn-request-format edn-response-format]]
             [clojure.edn :as edn]
             [day8.re-frame.http-fx]
-            [re-frame.core :as rf]
-            [clojure.string :as str]
-            [flybot.client.web.core.dom.page.post :as post]
-            [sg.flybot.pullable :as pull]))
+            [re-frame.core :as rf]))
 
 ;; Overridden by the figwheel config option :closure-defines
 (goog-define BASE-URI "")
@@ -16,46 +13,6 @@
   "Given the relative `path`, use the BASE-URI to build the absolute path uri."
   [path]
   (str BASE-URI path))
-
-;;; Routing
-
-(rf/reg-event-fx
- :evt.nav/redirect-post-url
- (fn [{:keys [db]} [_ default-name default-page-name]]
-   (let [[name page-name id-ending url-identifier :as params]
-         ((pull/qfn {:app/current-view
-                     {:data
-                      {(list :name :not-found default-name)
-                       '?name
-                       (list :page-name :not-found default-page-name)
-                       '?page-name}
-                      :path-params
-                      {:id-ending '?id-ending
-                       :url-identifier '?url-identifier}}}
-                    [?name ?page-name ?id-ending ?url-identifier])
-          db)
-         matches-page? (fn [post] (-> post :post/page (= page-name)))
-         matches-id-ending? (fn [id] (str/ends-with? (str id) id-ending))
-         matches-url-identifier? (fn [post]
-                                   (= url-identifier
-                                      (post/post-url-identifier post)))
-         queried-post (->>
-                       (:app/posts db)
-                       (into {}
-                             (filter (fn [[id post]]
-                                       (and (matches-id-ending? id)
-                                            (matches-page? post)))))
-                       vals
-                       first)]
-     (if (or (nil? queried-post) (matches-url-identifier? queried-post))
-       ;; Don't redirect if there're no page-ID matches, or if there's a
-       ;; complete match
-       {}
-       ;; Redirect on partial match
-       {:fx.router/replace-state
-        [name
-         {:id-ending id-ending
-          :url-identifier (post/post-url-identifier queried-post)}]}))))
 
 ;; ---------- http success/failure ----------
 

--- a/client/common/src/flybot/client/common/db/fx.cljs
+++ b/client/common/src/flybot/client/common/db/fx.cljs
@@ -2,12 +2,6 @@
   (:require [re-frame.core :as rf]
             [reitit.frontend.easy :as rfe]))
 
-;; -- Producing pure results ---
-
-(rf/reg-fx
- :fx.pure/pure
- identity)
-
 ;; ---------- Routing ----------
 
 (rf/reg-fx

--- a/client/common/src/flybot/client/common/db/fx.cljs
+++ b/client/common/src/flybot/client/common/db/fx.cljs
@@ -1,5 +1,18 @@
 (ns flybot.client.common.db.fx
-  (:require [re-frame.core :as rf]))
+  (:require [re-frame.core :as rf]
+            [reitit.frontend.easy :as rfe]))
+
+;; -- Producing pure results ---
+
+(rf/reg-fx
+ :fx.pure/pure
+ identity)
+
+;; ---------- Routing ----------
+
+(rf/reg-fx
+ :fx.router/replace-state
+ (fn [args] (apply rfe/replace-state args)))
 
 ;; ---------- Logging ----------
 

--- a/client/web/src/flybot/client/web/core/db/event.cljs
+++ b/client/web/src/flybot/client/web/core/db/event.cljs
@@ -149,9 +149,4 @@
 (rf/reg-event-db
  :evt.page/set-current-view
  (fn [db [_ new-match]]
-   (let [old-match (-> db :app/current-view)
-         match (assoc new-match
-                      :controllers
-                      (rfc/apply-controllers (:controllers old-match)
-                                             new-match))]
-     (assoc db :app/current-view match))))
+   (assoc db :app/current-view new-match)))

--- a/client/web/src/flybot/client/web/core/db/event.cljs
+++ b/client/web/src/flybot/client/web/core/db/event.cljs
@@ -22,7 +22,7 @@
            [:dispatch [:evt.post/set-modes :read]]
            [:fx.log/message ["Post " id " sent."]]]})))
 
-;;; Routing
+;; ---------------- Routing -----------------
 
 ;; Redirecting incorrect/old post URLs
 
@@ -52,11 +52,8 @@
                                             (matches-page? post)))))
                        vals
                        first)]
-     (if (or (nil? queried-post) (matches-url-identifier? queried-post))
-       ;; Don't redirect if there're no page-ID matches, or if there's a
-       ;; complete match
-       {}
-       ;; Redirect on partial match
+     (when (and queried-post (not (matches-url-identifier? queried-post)))
+       ;; Redirect on partial match (when everything matches except post title)
        {:fx.router/replace-state
         [(get router/redirect-name-map name)
          {:id-ending id-ending

--- a/client/web/src/flybot/client/web/core/db/event.cljs
+++ b/client/web/src/flybot/client/web/core/db/event.cljs
@@ -4,7 +4,8 @@
             [ajax.edn :refer [edn-request-format edn-response-format]]
             [day8.re-frame.http-fx]
             [re-frame.core :as rf]
-            [reitit.frontend.easy :as rfe]))
+            [reitit.frontend.easy :as rfe]
+            [reitit.frontend.controllers :as rfc]))
 
 ;; ---------- http success/failure ----------
 
@@ -104,4 +105,9 @@
 (rf/reg-event-db
  :evt.page/set-current-view
  (fn [db [_ new-match]]
-   (assoc db :app/current-view new-match)))
+   (let [old-match (-> db :app/current-view)
+         match (assoc new-match
+                      :controllers
+                      (rfc/apply-controllers (:controllers old-match)
+                                             new-match))]
+     (assoc db :app/current-view match))))

--- a/client/web/src/flybot/client/web/core/db/event.cljs
+++ b/client/web/src/flybot/client/web/core/db/event.cljs
@@ -4,7 +4,6 @@
             [day8.re-frame.http-fx]
             [flybot.client.common.db.event]
             [flybot.client.web.core.dom.page.post :as post]
-            [flybot.client.web.core.router :as router]
             [flybot.common.utils :as utils :refer [toggle]]
             [re-frame.core :as rf]
             [reitit.frontend.easy :as rfe]

--- a/client/web/src/flybot/client/web/core/db/event.cljs
+++ b/client/web/src/flybot/client/web/core/db/event.cljs
@@ -4,6 +4,7 @@
             [day8.re-frame.http-fx]
             [flybot.client.common.db.event]
             [flybot.client.web.core.dom.page.post :as post]
+            [flybot.client.web.core.router :as router]
             [flybot.common.utils :as utils :refer [toggle]]
             [re-frame.core :as rf]
             [reitit.frontend.easy :as rfe]
@@ -27,14 +28,12 @@
 
 (rf/reg-event-fx
  :evt.nav/redirect-post-url
- (fn [{:keys [db]} [_ default-name default-page-name]]
+ (fn [{:keys [db]} [_]]
    (let [[name page-name id-ending url-identifier]
          ((pull/qfn {:app/current-view
                      {:data
-                      {(list :name :not-found default-name)
-                       '?name
-                       (list :page-name :not-found default-page-name)
-                       '?page-name}
+                      {:name '?name
+                       :page-name '?page-name}
                       :path-params
                       {:id-ending '?id-ending
                        :url-identifier '?url-identifier}}}
@@ -59,7 +58,7 @@
        {}
        ;; Redirect on partial match
        {:fx.router/replace-state
-        [name
+        [(get router/redirect-name-map name)
          {:id-ending id-ending
           :url-identifier (post/post-url-identifier queried-post)}]}))))
 

--- a/client/web/src/flybot/client/web/core/db/event.cljs
+++ b/client/web/src/flybot/client/web/core/db/event.cljs
@@ -29,15 +29,20 @@
 (rf/reg-event-fx
  :evt.nav/redirect-post-url
  (fn [{:keys [db]} [_]]
-   (let [[name page-name id-ending url-identifier]
+   (let [[name redirect-name page-name id-ending url-identifier]
          ((pull/qfn {:app/current-view
                      {:data
                       {:name '?name
+                       :redirect-name '?redirect-name
                        :page-name '?page-name}
                       :path-params
                       {:id-ending '?id-ending
                        :url-identifier '?url-identifier}}}
-                    [?name ?page-name ?id-ending ?url-identifier])
+                    [?name
+                     ?redirect-name
+                     ?page-name
+                     ?id-ending
+                     ?url-identifier])
           db)
          matches-page? (fn [post] (-> post :post/page (= page-name)))
          matches-id-ending? (fn [id] (str/ends-with? (str id) id-ending))
@@ -55,7 +60,7 @@
      (when (and queried-post (not (matches-url-identifier? queried-post)))
        ;; Redirect on partial match (when everything matches except post title)
        {:fx.router/replace-state
-        [(get router/redirect-name-map name)
+        [(or name redirect-name)
          {:id-ending id-ending
           :url-identifier (post/post-url-identifier queried-post)}]}))))
 

--- a/client/web/src/flybot/client/web/core/router.cljs
+++ b/client/web/src/flybot/client/web/core/router.cljs
@@ -32,7 +32,16 @@
    ["/blog/:id-ending/:url-identifier"
     {:name :flybot/blog-post
      :page-name :blog
-     :view blog-single-post-page}]
+     :view blog-single-post-page
+     :controllers
+     [{:parameters {:path [:id-ending :url-identifier]}
+       :start (fn [{{:keys [id-ending url-identifier]} :path}]
+                (js/console.log "CONTROLLER STARTS")
+                (rf/dispatch [:evt.nav/redirect-post-url
+                              :flybot/blog-post
+                              :blog
+                              id-ending
+                              url-identifier]))}]}]
 
    ["#footer-contact"
     {:name :flybot/contact}]])

--- a/client/web/src/flybot/client/web/core/router.cljs
+++ b/client/web/src/flybot/client/web/core/router.cljs
@@ -32,17 +32,22 @@
    ["/blog/:id-ending"
     {:page-name :blog
      :view #(do
-              (rf/dispatch [:evt.nav/redirect-post-url
-                            :flybot/blog-post
-                            :blog])
+              (rf/dispatch [:evt.nav/redirect-post-url])
               (blog-single-post-page))}
-    [""]
-    ["/"]
+    [""
+     {:name :flybot/-blog>id}]
+    ["/"
+     {:name :flybot/-blog>id>}]
     ["/:url-identifier"
      {:name :flybot/blog-post}]]
 
    ["#footer-contact"
     {:name :flybot/contact}]])
+
+(def redirect-name-map
+  {:flybot/-blog>id :flybot/blog-post
+   :flybot/-blog>id> :flybot/blog-post
+   :flybot/blog-post :flybot/blog-post})
 
 (def router
   (rei/router routes))

--- a/client/web/src/flybot/client/web/core/router.cljs
+++ b/client/web/src/flybot/client/web/core/router.cljs
@@ -29,19 +29,17 @@
      :page-name :blog
      :view blog-all-posts-page}]
 
-   ["/blog/:id-ending/:url-identifier"
-    {:name :flybot/blog-post
-     :page-name :blog
-     :view blog-single-post-page
-     :controllers
-     [{:parameters {:path [:id-ending :url-identifier]}
-       :start (fn [{{:keys [id-ending url-identifier]} :path}]
-                (js/console.log "CONTROLLER STARTS")
-                (rf/dispatch [:evt.nav/redirect-post-url
-                              :flybot/blog-post
-                              :blog
-                              id-ending
-                              url-identifier]))}]}]
+   ["/blog/:id-ending"
+    {:page-name :blog
+     :view #(do
+              (rf/dispatch [:evt.nav/redirect-post-url
+                            :flybot/blog-post
+                            :blog])
+              (blog-single-post-page))}
+    [""]
+    ["/"]
+    ["/:url-identifier"
+     {:name :flybot/blog-post}]]
 
    ["#footer-contact"
     {:name :flybot/contact}]])

--- a/client/web/src/flybot/client/web/core/router.cljs
+++ b/client/web/src/flybot/client/web/core/router.cljs
@@ -35,19 +35,14 @@
               (rf/dispatch [:evt.nav/redirect-post-url])
               (blog-single-post-page))}
     [""
-     {:name :flybot/-blog>id}]
+     {:redirect-name :flybot/blog-post}]
     ["/"
-     {:name :flybot/-blog>id>}]
+     {:redirect-name :flybot/blog-post}]
     ["/:url-identifier"
      {:name :flybot/blog-post}]]
 
    ["#footer-contact"
     {:name :flybot/contact}]])
-
-(def redirect-name-map
-  {:flybot/-blog>id :flybot/blog-post
-   :flybot/-blog>id> :flybot/blog-post
-   :flybot/blog-post :flybot/blog-post})
 
 (def router
   (rei/router routes))

--- a/client/web/test/flybot/client/web/core/router_test.cljs
+++ b/client/web/test/flybot/client/web/core/router_test.cljs
@@ -1,0 +1,128 @@
+(ns flybot.client.web.core.router-test
+  (:require
+   [cljs.test :refer [deftest is testing use-fixtures]]
+   [day8.re-frame.test :as rf-test]
+   [flybot.client.web.core.router :as sut]
+   [flybot.common.test-sample-data :as s]
+   [flybot.common.utils :as utils]
+   [re-frame.core :as rf]
+   [reitit.core :as r]))
+
+(use-fixtures :once
+  {:before (fn [] (sut/init-routes!))})
+
+;;; Initialization
+
+(defn test-fixtures
+  "Set local storage values and initialize DB with sample data."
+  []
+  ;; Mock local storage store
+  (rf/reg-cofx
+   :cofx.app/local-store-theme
+   (fn [coeffects _]
+     (assoc coeffects :local-store-theme :dark)))
+  ;; Mock success http request
+  (rf/reg-fx :http-xhrio
+             (fn [_]
+               (rf/dispatch [:fx.http/all-success s/init-pages-and-posts])))
+  ;; Initialize db
+  (rf/dispatch [:evt.app/initialize]))
+
+;;; Test
+
+(deftest redirect-blog-post-url-test
+  (with-redefs [utils/mk-date (constantly s/post-1-create-date)]
+    (rf-test/run-test-sync
+     (test-fixtures)
+     (let [temp-id "new-post-temp-id"
+           empty-post {:post/id temp-id
+                       :post/page :blog
+                       :post/mode :edit
+                       :post/author {:user/id "bob-id" :user/name "Bob"}
+                       :post/creation-date (utils/mk-date)}
+           post-mode (rf/subscribe [:subs/pattern
+                                    {:app/posts {temp-id '{:post/mode ?x}}}])
+           posts (rf/subscribe [:subs.post/posts :blog])
+           new-post-md-content-1 "#New! Post! Has! Arrived!!!"
+           new-post-md-content-2 "# Post has been edited."
+           new-post-1 (assoc empty-post :post/md-content new-post-md-content-1)
+           new-post-2 (assoc empty-post :post/md-content new-post-md-content-2)
+           get-current-view (rf/subscribe
+                             [:subs/pattern
+                              {:app/current-view
+                               {:data
+                                {:name '?name
+                                 :page-name '?page-name}
+                                :path-params
+                                {:id-ending '?id-ending
+                                 :url-identifier '?url-identifier}}}])
+           go-to-link (fn [path] (->> path
+                                      (r/match-by-path sut/router)
+                                      sut/on-navigate))]
+
+       (testing "Create post:"
+         (testing "Mode should be nil before post is sent:"
+           (is (nil? @post-mode)))
+         (testing "Toggle mode from nil to :edit; add content:"
+           (rf/dispatch [:evt.post/toggle-edit-mode temp-id])
+           (is (= :edit @post-mode))
+           (rf/dispatch [:evt.post.form/set-field
+                         :post/md-content new-post-md-content-1]))
+         (testing "New post sent successfully:"
+           (rf/reg-fx :http-xhrio
+                      (fn [_] (rf/dispatch
+                               [:fx.http/send-post-success
+                                {:posts {:new-post new-post-1}}])))
+           ;; Send post with new content to server
+           (rf/dispatch [:evt.post.form/send-post])
+           (is (= [(assoc new-post-1 :post/mode :read)]
+                  @posts))))
+
+       (testing "Links to new post:"
+         (let [expected-view {'?name :flybot/blog-post
+                              '?page-name :blog
+                              '?id-ending "-temp-id"
+                              '?url-identifier "New_Post_Has_Arrived"}]
+           (testing "Correct link goes to correct view:"
+             (go-to-link "/blog/-temp-id/New_Post_Has_Arrived")
+             (is (= expected-view (dissoc @get-current-view '&?))))
+           (testing "Link with wrong title goes to correct view:"
+             (go-to-link "/blog/-temp-id/wrong_title")
+             (is (= expected-view (dissoc @get-current-view '&?))))
+           (testing "Link with no title goes to correct view:"
+             (go-to-link "/blog/-temp-id/")
+             (is (= expected-view (dissoc @get-current-view '&?))))))
+
+       (testing "Edit post with new title:"
+         (testing "Post is in :edit mode:"
+           (rf/dispatch [:evt.post/toggle-edit-mode temp-id])
+           (is (= :edit @post-mode)))
+         (testing "Edit post content; send post:"
+           (rf/dispatch [:evt.post.form/set-field
+                         :post/md-content new-post-md-content-2])
+           (rf/reg-fx :http-xhrio
+                      (fn [_]
+                        (rf/dispatch [:fx.http/send-post-success
+                                      {:posts {:new-post new-post-2}}])))
+           ;; Send post with new content to server
+           (rf/dispatch [:evt.post.form/send-post])
+           (is (= [(assoc new-post-2 :post/mode :read)]
+                  @posts))))
+
+       (testing "Links to edited post:"
+         (let [expected-view {'?name :flybot/blog-post
+                              '?page-name :blog
+                              '?id-ending "-temp-id"
+                              '?url-identifier "Post_has_been_edited"}]
+           (testing "Correct link goes to correct view:"
+             (go-to-link "/blog/-temp-id/Post_has_been_edited")
+             (is (= expected-view (dissoc @get-current-view '&?))))
+           (testing "Link with old title goes to correct view:"
+             (go-to-link "/blog/-temp-id/New_Post_Has_Arrived")
+             (is (= expected-view (dissoc @get-current-view '&?))))
+           (testing "Link with wrong title goes to correct view:"
+             (go-to-link "/blog/-temp-id/wrong_title")
+             (is (= expected-view (dissoc @get-current-view '&?))))
+           (testing "Link with no title goes to correct view:"
+             (go-to-link "/blog/-temp-id/")
+             (is (= expected-view (dissoc @get-current-view '&?))))))))))

--- a/client/web/test/flybot/client/web/core/router_test.cljs
+++ b/client/web/test/flybot/client/web/core/router_test.cljs
@@ -6,9 +6,7 @@
    [flybot.common.test-sample-data :as s]
    [flybot.common.utils :as utils]
    [re-frame.core :as rf]
-   [reitit.core :as r]
-   [reitit.frontend.easy :as rfe]
-   [sg.flybot.pullable :as pull]))
+   [reitit.core :as r]))
 
 (use-fixtures :once
   {:before (fn [] (sut/init-routes!))})

--- a/client/web/test/flybot/client/web/core/router_test.cljs
+++ b/client/web/test/flybot/client/web/core/router_test.cljs
@@ -59,15 +59,9 @@
                                 {:id-ending '?id-ending
                                  :url-identifier '?url-identifier}}}])
            go-to-link (fn [path]
-                        (let [[name path-params]
-                              ((pull/qfn
-                                {:data
-                                 {:name '?name}
-                                 :path-params '?path-params}
-                                [?name ?path-params])
-                               (r/match-by-path sut/router path))]
-                          (rfe/replace-state name path-params)
-                          (rf/dispatch [:evt.nav/redirect-post-url])))]
+                        (rf/dispatch [:evt.page/set-current-view
+                                      (r/match-by-path sut/router path)])
+                        (rf/dispatch [:evt.nav/redirect-post-url]))]
 
        (testing "Create post:"
          (testing "Mode should be nil before post is sent:"

--- a/client/web/test/flybot/client/web/core/router_test.cljs
+++ b/client/web/test/flybot/client/web/core/router_test.cljs
@@ -101,6 +101,9 @@
              (is (= expected-view (dissoc @get-current-view '&?))))
            (testing "Link with no title goes to correct view:"
              (go-to-link "/blog/-temp-id/")
+             (is (= expected-view (dissoc @get-current-view '&?))))
+           (testing "Link with only post ID goes to correct view:"
+             (go-to-link "/blog/-temp-id")
              (is (= expected-view (dissoc @get-current-view '&?))))))
 
        (testing "Edit post with new title:"
@@ -135,4 +138,7 @@
              (is (= expected-view (dissoc @get-current-view '&?))))
            (testing "Link with no title goes to correct view:"
              (go-to-link "/blog/-temp-id/")
+             (is (= expected-view (dissoc @get-current-view '&?))))
+           (testing "Link with only post ID goes to correct view:"
+             (go-to-link "/blog/-temp-id")
              (is (= expected-view (dissoc @get-current-view '&?))))))))))

--- a/client/web/test/flybot/client/web/core/router_test.cljs
+++ b/client/web/test/flybot/client/web/core/router_test.cljs
@@ -59,7 +59,7 @@
                                 {:id-ending '?id-ending
                                  :url-identifier '?url-identifier}}}])
            go-to-link (fn [path]
-                        (let [[name path-params :as match]
+                        (let [[name path-params]
                               ((pull/qfn
                                 {:data
                                  {:name '?name}
@@ -67,8 +67,7 @@
                                 [?name ?path-params])
                                (r/match-by-path sut/router path))]
                           (rfe/replace-state name path-params)
-                          (rf/dispatch [:evt.nav/redirect-post-url])
-                          (print match)))]
+                          (rf/dispatch [:evt.nav/redirect-post-url])))]
 
        (testing "Create post:"
          (testing "Mode should be nil before post is sent:"

--- a/client/web/test/flybot/client/web/test_runner.cljs
+++ b/client/web/test/flybot/client/web/test_runner.cljs
@@ -5,6 +5,7 @@
     [flybot.client.web.core.db-test]
     [flybot.client.web.core.dom.common.link-test]
     [flybot.client.web.core.dom.page.post-test]
+    [flybot.client.web.core.router-test]
     [flybot.common.validation.markdown-test]))
 
 (defn -main [& args]


### PR DESCRIPTION
## Closes #164

- [x] Redirect post URLs with wrong or old titles.

    Post URLs such as

    - `/blog/post-id-ending/wrong_title`
    - `/blog/post-id-ending/old_title`
    - `/blog/post-id-ending/` (no title)
    - `/blog/post-id-ending` (no slash, no title)

    are redirected to `/blog/post-id-ending/latest_title`.

### Details

The router dispatches a re-frame event effect to redirect instead of querying the correct post title directly.[^1][^2]

The event is dispatched just before page rendering rather than inside the `:start` route controller. This is due to a race condition—the controller code is sometimes run before the full list of posts is fully loaded, so an event dispatched inside the controller would not be able to query the correct title from the incomplete post list.

[^1]: https://day8.github.io/re-frame/FAQs/UseASubscriptionInAJsEvent/
[^2]: https://day8.github.io/re-frame/FAQs/UseASubscriptionInAnEventHandler/