### PR TITLE
170 post authors only shows on blog

### DIFF
--- a/client/web/src/flybot/client/web/core/dom/page.cljs
+++ b/client/web/src/flybot/client/web/core/dom/page.cljs
@@ -39,6 +39,7 @@
     [:section.container
      {:class (name page-name)
       :key   (name page-name)}
+     [:h1.page-title page-name]
      [page-header page-name]
      [page-post :blog new-post]
      (doall

--- a/client/web/src/flybot/client/web/core/dom/page.cljs
+++ b/client/web/src/flybot/client/web/core/dom/page.cljs
@@ -65,12 +65,9 @@
       :key (name :blog)}
      [page-header :blog]
      [page-post :blog new-post]
-     [:div.post
-      [:h1.page-title "Blog"]]
-     [:div.post.post-list
-      (doall
-       (for [post ordered-posts]
-         (list-entry-post post)))]]))
+     (doall
+      (for [post ordered-posts]
+        (list-entry-post post)))]))
 
 (defn blog-single-post-page
   "Given the blog post identifier, returns the corresponding post in a page.

--- a/client/web/src/flybot/client/web/core/dom/page/post.cljs
+++ b/client/web/src/flybot/client/web/core/dom/page/post.cljs
@@ -204,20 +204,21 @@
       [:div {:key "action"} "(Edited)"]])])
 
 (defn post-authors
-  [{:post/keys [author last-editor creation-date last-edit-date]}]
-  (let [author-name (:user/name author)
-        editor-name (:user/name last-editor)]
-    [:div.post-authors
-     (cond (not last-editor)
-           (user-info author-name creation-date nil :author)
+  [{:post/keys [author last-editor creation-date last-edit-date page]}]
+  (when (= :blog page)
+    (let [author-name (:user/name author)
+          editor-name (:user/name last-editor)]
+      [:div.post-authors
+       (cond (not last-editor)
+             (user-info author-name creation-date nil :author)
 
-           (= author last-editor)
-           (user-info author-name creation-date last-edit-date :author)
+             (= author last-editor)
+             (user-info author-name creation-date last-edit-date :author)
 
-           :else
-           [:<>
-            (user-info author-name creation-date nil :author)
-            (user-info editor-name last-edit-date nil :editor)])]))
+             :else
+             [:<>
+              (user-info author-name creation-date nil :author)
+              (user-info editor-name last-edit-date nil :editor)])])))
 
 (defn post-view
   [{:post/keys [css-class image-beside hiccup-content] :as post}]
@@ -313,7 +314,7 @@
           :else
           (post-read post))))
 
-(defn list-entry-post
+(defn blog-post-short
   [{:post/keys [css-class hiccup-content id] :as post}]
   (let [post-title (-> hiccup-content
                        (mth/hiccup-in :h1 0)

--- a/client/web/src/flybot/client/web/core/router.cljs
+++ b/client/web/src/flybot/client/web/core/router.cljs
@@ -1,7 +1,5 @@
 (ns flybot.client.web.core.router
-  (:require [flybot.client.web.core.dom.page :refer [page
-                                                     blog-all-posts-page
-                                                     blog-single-post-page]]
+  (:require [flybot.client.web.core.dom.page :refer [page blog-single-post-page]]
             [goog.object :as gobj]
             [reitit.frontend :as rei]
             [reitit.frontend.easy :as rfe]
@@ -27,7 +25,7 @@
    ["/blog"
     {:name :flybot/blog
      :page-name :blog
-     :view blog-all-posts-page}]
+     :view #(page :blog)}]
 
    ["/blog/:id-ending"
     {:page-name :blog

--- a/resources/public/css/style.css
+++ b/resources/public/css/style.css
@@ -412,6 +412,16 @@ section .page-header h1 {
     text-align: center;
 }
 
+section h1.page-title {
+    background-color: var(--text-primary-color);
+    color: var(--bg-secondary-color);
+    text-align: center;
+    border-style: solid;
+    border-width: 1px;
+    border-color: var(--border-primary-color);
+    border-top: none;
+}
+
 @media (max-width: 1024px) {
     section .page-header {
         padding: 0.5rem;
@@ -579,7 +589,10 @@ section .team img {
 /* Admin */
 
 .admin {
-    padding-top: 1rem;
+    padding: 1rem;
+    border-bottom-style: solid;
+    border-bottom-width: 1px;
+    border-bottom-color: var(--border-primary-color);
 }
 
 section.admin h1 {

--- a/resources/public/css/style.css
+++ b/resources/public/css/style.css
@@ -540,6 +540,7 @@ section .team img {
 
 .post-authors {
     font-size: 0.8rem;
+    overflow-x: auto;
     border-bottom: groove;
     border-bottom-width: thin;
     border-color: var(--text-tertiary-color);
@@ -553,6 +554,8 @@ section .team img {
 .post-author {
     display: flex;
     align-items: center;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 }
 
 @media (max-width: 1024px) {
@@ -617,6 +620,11 @@ section.admin h1 {
 }
 
 .blog .short .post-authors {
-    display: flex;
     border: none;
+}
+
+@media (max-width: 1024px) {
+    .blog .post.short .post-authors {
+        display: block;
+    }
 }

--- a/resources/public/css/style.css
+++ b/resources/public/css/style.css
@@ -13,6 +13,7 @@
 
     --text-primary-color: #bae6fd;
     --text-secondary-color: #f0f9ff;
+    --text-tertiary-color: lightgray;
 
     --button-primary-color: black;
 
@@ -26,6 +27,7 @@
 
     --text-primary-color: #0ea5e9;
     --text-secondary-color: #18181b;
+    --text-tertiary-color: grey;
 
     --button-primary-color: white;
 
@@ -262,8 +264,8 @@ input[type=button] {
 }
 
 .post-icon {
-    width: 22px;
-    height: 22px;
+    width: 14px;
+    height: 14px;
 }
 
 .burger {
@@ -537,14 +539,20 @@ section .team img {
 /* Post */
 
 .post-authors {
+    font-size: 0.8rem;
     border-bottom: groove;
     border-bottom-width: thin;
+    border-color: var(--text-tertiary-color);
+    color: var(--text-tertiary-color);
+}
+
+.post-authors svg {
+    fill: var(--text-tertiary-color);
 }
 
 .post-author {
     display: flex;
     align-items: center;
-    font-size: 0.8rem;
 }
 
 @media (max-width: 1024px) {
@@ -573,4 +581,42 @@ section .team img {
 
 section.admin h1 {
     text-align: center;
+}
+
+/* Blog Page */
+
+.blog .post.short {
+    background-color: inherit;
+    padding: 0;
+    border: none;
+    border-bottom-width: 1px;
+    border-bottom-color: var(--border-primary-color);
+    border-bottom-style: solid;
+}
+
+.blog .post.short .post-body {
+    display: block;
+    padding: 0.5rem;
+}
+
+.blog .post.short .post-body:hover {
+    background-color: var(--bg-primary-color);
+    border-left-width: 1px;
+    border-left-color: var(--border-primary-color);
+    border-left-style: solid;
+}
+
+.blog .post.short .post-body>* {
+    padding: 0.5rem;
+}
+
+.blog .post.short a {
+    display: block;
+    padding: 0;
+    text-decoration: none;
+}
+
+.blog .short .post-authors {
+    display: flex;
+    border: none;
 }

--- a/server/src/flybot/server/core/init_data.clj
+++ b/server/src/flybot/server/core/init_data.clj
@@ -6,15 +6,22 @@
 
 ;; ---------- Initial Data ----------
 
+(def user-admin
+  (-> (edn/read-string (or (System/getenv "ADMIN_USER")
+                           (slurp "config/admin.edn")))
+      (assoc :user/roles [#:role{:name :editor
+                                 :date-granted (u/mk-date)}
+                          #:role{:name :admin
+                                 :date-granted (u/mk-date)}])))
+
+(def user-alice
+  #:user{:id "alice-id"
+         :email "alice@basecity.com"
+         :name "Alice Martin"
+         :roles [#:role{:name :editor
+                        :date-granted (u/mk-date)}]})
 (def users
-  (let [admin (edn/read-string (or (System/getenv "ADMIN_USER")
-                                   (slurp "config/admin.edn")))]
-    (-> admin
-        (assoc :user/roles [#:role{:name :editor
-                                   :date-granted (u/mk-date)}
-                            #:role{:name :admin
-                                   :date-granted (u/mk-date)}])
-        vector)))
+  [user-admin user-alice])
 
 (defn slurp-md
   "Slurp the sample files with the markdown."
@@ -68,8 +75,8 @@
           :last-edit-date (u/mk-date)
           :show-dates? true
           :show-authors? true
-          :author (first users)
-          :last-editor (first users)
+          :author user-admin
+          :last-editor user-admin
           :md-content (slurp-md "blog" "welcome.md")
           :image-beside #:image{:src "/assets/flybot-logo.png"
                                 :src-dark "/assets/flybot-logo.png"
@@ -81,8 +88,8 @@
           :last-edit-date (u/mk-date)
           :show-dates? true
           :show-authors? true
-          :author (first users)
-          :last-editor (first users)
+          :author user-alice
+          :last-editor user-admin
           :md-content (slurp-md "blog" "mdsample.md")
           :image-beside #:image{:src "https://octodex.github.com/images/dojocat.jpg"
                                 :src-dark "https://octodex.github.com/images/stormtroopocat.jpg"


### PR DESCRIPTION
Closes #170 
---

- always show post-authors on blog page
- never show post-authors on other pages
- only show the author name once if same author/editor for edited post
- remove `blog-all-posts-page` as the logic could be added in `page`
- improve css for blog page
- add a dummy `alice` user to init-data to highlight the case where post as different author and last editor
- add h1 title to each page