### PR TITLE
Add server-side validation to pattern :with params

### DIFF
--- a/common/src/flybot/common/validation.cljc
+++ b/common/src/flybot/common/validation.cljc
@@ -49,11 +49,11 @@
 (def post-schema-create
   "The differences with `post-schema` are that:
    - only the id of the author/last-editor is required.
-   - the keys are locked so they won't be affected by all-keys-optional."
+   - the required keys won't be affected by all-keys-optional."
   (-> post-schema
       (mu/assoc :post/author author-schema)
       (mu/assoc :post/last-editor author-schema)
-      (mu/update-properties assoc :locked-keys true)))
+      (mu/update-properties assoc :preserve-required true)))
 
 (def page-schema
   [:map {:closed true}
@@ -66,8 +66,8 @@
 
 (def page-schema-create
   "The difference with `page-schema` is that:
-     - the keys are locked so they won't be affected by all-keys-optional."
-  (mu/update-properties page-schema assoc :locked-keys true))
+     - the required keys won't be affected by all-keys-optional."
+  (mu/update-properties page-schema assoc :preserve-required true))
 
 (defn all-keys-optional
   "Walk through the given `schema` and set all keys to optional."
@@ -77,7 +77,7 @@
    (m/schema-walker
     (fn [sch]
       (if (and (= :map (m/type sch))
-               (-> sch m/properties :locked-keys not))
+               (-> sch m/properties :preserve-required not))
         (mu/optional-keys sch)
         sch)))))
 
@@ -85,7 +85,7 @@
 
 (def api-schema
   "All keys are optional because it is just a data query schema.
-   maps with a property :locked-keys set to true have their keys remaining unchanged."
+   maps with a property :preserve-required set to true have their keys remaining unchanged."
   (all-keys-optional
    [:map
     {:closed true}

--- a/common/src/flybot/common/validation.cljc
+++ b/common/src/flybot/common/validation.cljc
@@ -50,11 +50,10 @@
   "The differences with `post-schema` are that:
    - only the id of the author/last-editor is required.
    - the keys are locked so they won't be affected by all-keys-optional."
-  (let [sch        (-> post-schema
-                       (mu/assoc :post/author author-schema)
-                       (mu/assoc :post/last-editor author-schema))
-        properties (assoc (m/properties sch) :locked-keys true)]
-    (m/into-schema (m/type sch) properties (m/children sch) (m/options sch))))
+  (-> post-schema
+      (mu/assoc :post/author author-schema)
+      (mu/assoc :post/last-editor author-schema)
+      (mu/update-properties assoc :locked-keys true)))
 
 (def page-schema
   [:map {:closed true}
@@ -68,9 +67,7 @@
 (def page-schema-create
   "The difference with `page-schema` is that:
      - the keys are locked so they won't be affected by all-keys-optional."
-  (let [sch        page-schema
-        properties (assoc (m/properties sch) :locked-keys true)]
-    (m/into-schema (m/type sch) properties (m/children sch) (m/options sch))))
+  (mu/update-properties page-schema assoc :locked-keys true))
 
 (defn all-keys-optional
   "Walk through the given `schema` and set all keys to optional."
@@ -84,13 +81,11 @@
         (mu/optional-keys sch)
         sch)))))
 
-
-
 ;;---------- Pull Schemas ----------
 
 (def api-schema
   "All keys are optional because it is just a data query schema.
-   maps with a property :locked-keys set to true have their keys remain unchanged."
+   maps with a property :locked-keys set to true have their keys remaining unchanged."
   (all-keys-optional
    [:map
     {:closed true}

--- a/common/test/flybot/common/test_sample_data.cljc
+++ b/common/test/flybot/common/test_sample_data.cljc
@@ -73,8 +73,6 @@
              :post/md-content    "# Post 3"
              :post/creation-date post-3-create-date
              :post/author        {:user/id bob-id}})
-(def post-3-missing-title
-  (assoc post-3 :post/md-content "No title"))
 
 (def init-pages-and-posts
   {:posts {:all [post-1 post-2]}

--- a/common/test/flybot/common/validation_test.cljc
+++ b/common/test/flybot/common/validation_test.cljc
@@ -18,19 +18,19 @@
            {:closed true}
            [:a [:vector :int]]
            [:b [:map [:c [:map [:d :keyword]]]]]]))))
-  (testing "map with property :locked-keys is not affected by keys optional."
+  (testing "map with property `:preserve-required` preserves required keys."
     (is (mu/equals
          [:cat
           [:map
            [:a {:optional true} :int]]
-          [:map {:closed true :locked-keys true}
+          [:map {:closed true :preserve-required true}
            [:a :int]
            [:b {:optional true} :int]]]
          (sut/all-keys-optional
           [:cat
            [:map
             [:a :int]]
-           [:map {:closed true :locked-keys true}
+           [:map {:closed true :preserve-required true}
             [:a :int]
             [:b {:optional true} :int]]])))))
 

--- a/common/test/flybot/common/validation_test.cljc
+++ b/common/test/flybot/common/validation_test.cljc
@@ -17,7 +17,22 @@
           [:map
            {:closed true}
            [:a [:vector :int]]
-           [:b [:map [:c [:map [:d :keyword]]]]]])))))
+           [:b [:map [:c [:map [:d :keyword]]]]]]))))
+  (testing "map with property :locked-keys is not affected by keys optional."
+    (is (mu/equals
+         [:cat
+          [:map
+           [:a {:optional true} :int]]
+          [:map {:closed true :locked-keys true}
+           [:a :int]
+           [:b {:optional true} :int]]]
+         (sut/all-keys-optional
+          [:cat
+           [:map
+            [:a :int]]
+           [:map {:closed true :locked-keys true}
+            [:a :int]
+            [:b {:optional true} :int]]])))))
 
 (deftest prepare-post
   (testing "Creation of a post."

--- a/deps.edn
+++ b/deps.edn
@@ -5,7 +5,7 @@
            metosin/muuntaja                      {:mvn/version "0.6.8"}
            markdown-to-hiccup/markdown-to-hiccup {:mvn/version "0.6.2"}
            sg.flybot/lasagna-pull                {:git/url "https://github.com/flybot-sg/lasagna-pull.git"
-                                                  :git/sha "550f499bfb48c363eb8a40b6ee1c0ab5c02608b0"}
+                                                  :git/sha "f9b91174a135a0e32e87441470e4209c04d87306"}
 
            ;; backend
            ring/ring-defaults                    {:mvn/version "0.3.4"}

--- a/server/src/flybot/server/core/handler/middleware.clj
+++ b/server/src/flybot/server/core/handler/middleware.clj
@@ -14,7 +14,7 @@
 (def exception-middleware
   "When a ex-data :type is matched, create a handler with custom status and error message."
   (exception/create-exception-middleware
-   {:pattern/schema            (partial handler 407 "Invalid pattern provided") ;; use status 500 for now
+   {:pattern/schema            (partial handler 407 "Invalid pattern provided")
     :user/login                (partial handler 408 "Cannot login because user does not exist")
     :user/delete               (partial handler 409 "Cannot delete because user does not exist")
     :user.admin/not-found      (partial handler 414 "User does not exist")

--- a/server/src/flybot/server/core/handler/operation.clj
+++ b/server/src/flybot/server/core/handler/operation.clj
@@ -36,8 +36,8 @@
   [db post]
   (let [author (db/get-user db (-> post :post/author :user/id))
         editor (db/get-user db (-> post :post/last-editor :user/id))
-        full-post (assoc post :post/author author)
-        full-post (if editor (assoc full-post :post/last-editor editor) full-post)]
+        full-post (cond-> (assoc post :post/author author)
+                    editor (assoc :post/last-editor editor))]
     {:response full-post
      :effects  {:db {:payload [full-post]}}}))
 

--- a/server/src/flybot/server/core/handler/operation.clj
+++ b/server/src/flybot/server/core/handler/operation.clj
@@ -31,9 +31,15 @@
 ;;---------- Ops with effects ----------
 
 (defn add-post
-  [post]
-  {:response post
-   :effects  {:db {:payload [post]}}})
+  "Add the post to the DB.
+   Returns the post with the full author/editor profile included."
+  [db post]
+  (let [author (db/get-user db (-> post :post/author :user/id))
+        editor (db/get-user db (-> post :post/last-editor :user/id))
+        full-post (assoc post :post/author author)
+        full-post (if editor (assoc full-post :post/last-editor editor) full-post)]
+    {:response full-post
+     :effects  {:db {:payload [full-post]}}}))
 
 (defn delete-post
   "Delete the post if
@@ -122,7 +128,7 @@
   [db session]
   {:posts {:all          (fn [] (get-all-posts db))
            :post         (fn [post-id] (get-post db post-id))
-           :new-post     (fn [post] (add-post post))
+           :new-post     (fn [post] (add-post db post))
            :removed-post (fn [post-id user-id] (delete-post db post-id user-id))}
    :pages {:all       (fn [] (get-all-pages db))
            :page      (fn [page-name] (get-page db page-name))

--- a/server/test/flybot/server/core/handler/operation_test.clj
+++ b/server/test/flybot/server/core/handler/operation_test.clj
@@ -24,6 +24,16 @@
 
 (use-fixtures :once system-fixture)
 
+(deftest add-post
+  (let [db-conn (-> test-system :db-conn :conn)]
+    (testing "Returns the proper response and effects."
+      (let [post-in s/post-3
+            post-out (assoc s/post-3 :post/author s/bob-user)]
+        (is (= {:response post-out
+                :effects {:db {:payload [post-out]}}}
+               (sut/add-post (d/db db-conn) post-in)))))))
+
+
 (deftest delete-post
   (let [db-conn (-> test-system :db-conn :conn)]
     (testing "User is admin so returns post delete effects."

--- a/server/test/flybot/server/core/handler_test.clj
+++ b/server/test/flybot/server/core/handler_test.clj
@@ -124,9 +124,9 @@
   (testing "Invalid http method so returns and index.html."
     (let [resp (http-request :get "/pages/page" ::PATTERN)]
       (is (= 204 (-> resp :status)))))
-  (testing "Invalid pattern so returns error 500."
+  (testing "Invalid pattern so returns error 407."
     (let [resp (http-request "/pages/page" {:invalid-key '?})]
-      (is (= 500 (-> resp :status)))))
+      (is (= 407 (-> resp :status)))))
   (testing "Cannot delete user who does not exist so returns 409."
     (let [resp (http-request "/pages/page"
                              {:users

--- a/server/test/flybot/server/core/handler_test.clj
+++ b/server/test/flybot/server/core/handler_test.clj
@@ -127,13 +127,6 @@
   (testing "Invalid pattern so returns error 500."
     (let [resp (http-request "/pages/page" {:invalid-key '?})]
       (is (= 500 (-> resp :status)))))
-  #_(testing "Invalid pattern in `:with` option so returns error 500."
-    (with-redefs [auth/has-permission? (constantly true)]
-      (let [resp (http-request "/posts/new-post"
-                               {:posts
-                                {(list :new-post :with [(dissoc s/post-3 :post/page)]) ;; pull pattern should throw error but don't
-                                 {:post/id '?}}})]
-        (is (= 500 (-> resp :status)))))) ;; TOFIX: current result: 200, expected result: 500.
   (testing "Cannot delete user who does not exist so returns 409."
     (let [resp (http-request "/pages/page"
                              {:users


### PR DESCRIPTION
Closes #175
---

## Changes

- add `locked-keys` optional malli property to maps so they are not affected by `all-keys-optional`
- bump lasagna-pull version
- update `add-post` so if only the author/editor ids are given, the whole auhtor/editor are returned (and therefore can be pulled)
- add a dedicated status `407` for pattern error be redefining `check-pattern!`

