### PR TITLE
Make front end display pages' custom post orders

### DIFF
--- a/client/common/src/flybot/client/common/db/event.cljs
+++ b/client/common/src/flybot/client/common/db/event.cljs
@@ -205,7 +205,8 @@
                                          :post/md-content '?
                                          :post/image-beside {:image/src '?
                                                              :image/src-dark '?
-                                                             :image/alt '?}}}}
+                                                             :image/alt '?}
+                                         :post/default-order '?}}}
                      :format          (edn-request-format {:keywords? true})
                      :response-format (edn-response-format {:keywords? true})
                      :on-success      [:fx.http/send-post-success]
@@ -241,7 +242,8 @@
                                        :post/md-content '?
                                        :post/image-beside {:image/src '?
                                                            :image/src-dark '?
-                                                           :image/alt '?}}}}
+                                                           :image/alt '?}
+                                       :post/default-order '?}}}
                    :format          (edn-request-format {:keywords? true})
                    :response-format (edn-response-format {:keywords? true})
                    :on-success      [:fx.http/post-success]

--- a/client/mobile/src/flybot/client/mobile/core/db/event.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/db/event.cljs
@@ -46,7 +46,8 @@
                              :post/md-content '?
                              :post/image-beside {:image/src '?
                                                  :image/src-dark '?
-                                                 :image/alt '?}}]}
+                                                 :image/alt '?}
+                             :post/default-order '?}]}
                           :users
                           {:auth
                            {(list :logged :with [])

--- a/client/web/src/flybot/client/web/core/db/event.cljs
+++ b/client/web/src/flybot/client/web/core/db/event.cljs
@@ -98,7 +98,8 @@
                                :post/md-content '?
                                :post/image-beside {:image/src '?
                                                    :image/src-dark '?
-                                                   :image/alt '?}}]}
+                                                   :image/alt '?}
+                               :post/default-order '?}]}
                             :users
                             {:auth
                              {(list :logged :with [])

--- a/client/web/src/flybot/client/web/core/dom/page.cljs
+++ b/client/web/src/flybot/client/web/core/dom/page.cljs
@@ -28,19 +28,19 @@
 (defn page
   "Given the `page-name`, returns the page content."
   [page-name]
-  (let [posts      (as-> @(rf/subscribe [:subs.post/posts page-name]) _
-                     (map post/add-post-hiccup-content _)
-                     (if (= :blog page-name)
-                       (sort-by :post/creation-date #(compare %2 %1) _)
-                       (sort-by :post/default-order _)))
-        new-post   {:post/id "new-post-temp-id"}]
+  (let [posts (->> @(rf/subscribe [:subs.post/posts page-name])
+                   (map post/add-post-hiccup-content))
+        sorted-posts (if (= :blog page-name)
+                       (sort-by :post/creation-date #(compare %2 %1) posts)
+                       (sort-by :post/default-order posts))
+        new-post {:post/id "new-post-temp-id"}]
     [:section.container
      {:class (name page-name)
       :key   (name page-name)}
      [:h1.page-title page-name]
      [page-post new-post]
      (doall
-      (for [post posts]
+      (for [post sorted-posts]
         (if (= :blog page-name)
           (blog-post-short post)
           (page-post post))))]))

--- a/client/web/src/flybot/client/web/core/dom/page.cljs
+++ b/client/web/src/flybot/client/web/core/dom/page.cljs
@@ -28,10 +28,11 @@
 (defn page
   "Given the `page-name`, returns the page content."
   [page-name]
-  (let [posts      (->> @(rf/subscribe [:subs.post/posts page-name])
-                        (map post/add-post-hiccup-content)
-                        (sort-by :post/creation-date)
-                        (reverse))
+  (let [posts      (as-> @(rf/subscribe [:subs.post/posts page-name]) _
+                     (map post/add-post-hiccup-content _)
+                     (if (= :blog page-name)
+                       (sort-by :post/creation-date #(compare %2 %1) _)
+                       (sort-by :post/default-order _)))
         new-post   {:post/id "new-post-temp-id"}]
     [:section.container
      {:class (name page-name)

--- a/server/src/flybot/server/core/init_data.clj
+++ b/server/src/flybot/server/core/init_data.clj
@@ -38,34 +38,40 @@
           :md-content (slurp-md "about" "company.md")
           :image-beside #:image{:src "/assets/flybot-logo.png"
                                 :src-dark "/assets/flybot-logo.png"
-                                :alt "Flybot Logo"}}
+                                :alt "Flybot Logo"}
+          :default-order 0}
    #:post{:id (u/mk-uuid)
           :page :about
           :css-class "team"
           :creation-date (u/mk-date)
-          :md-content (slurp-md "about" "team.md")}])
+          :md-content (slurp-md "about" "team.md")
+          :default-order 1}])
 
 (def apply-posts
   [#:post{:id (u/mk-uuid)
           :page :apply
           :css-class "description"
           :creation-date (u/mk-date)
-          :md-content (slurp-md "apply" "description.md")}
+          :md-content (slurp-md "apply" "description.md")
+          :default-order 0}
    #:post{:id (u/mk-uuid)
           :page :apply
           :css-class "qualifications"
           :creation-date (u/mk-date)
-          :md-content (slurp-md "apply" "qualifications.md")}
+          :md-content (slurp-md "apply" "qualifications.md")
+          :default-order 3}
    #:post{:id (u/mk-uuid)
           :page :apply
           :css-class "goal"
           :creation-date (u/mk-date)
-          :md-content (slurp-md "apply" "goal.md")}
+          :md-content (slurp-md "apply" "goal.md")
+          :default-order 2}
    #:post{:id (u/mk-uuid)
           :page :apply
           :css-class "application"
           :creation-date (u/mk-date)
-          :md-content (slurp-md "apply" "application.md")}])
+          :md-content (slurp-md "apply" "application.md")
+          :default-order 1}])
 
 (def blog-posts
   [#:post{:id (u/mk-uuid)
@@ -99,7 +105,8 @@
           :md-content (slurp-md "home" "clojure.md")
           :image-beside #:image{:src "/assets/clojure-logo.svg"
                                 :src-dark "/assets/clojure-logo-dark-mode.svg"
-                                :alt "Clojure Logo"}}
+                                :alt "Clojure Logo"}
+          :default-order 0}
    #:post{:id (u/mk-uuid)
           :page :home
           :css-class "paradigms"
@@ -107,7 +114,8 @@
           :md-content (slurp-md "home" "paradigms.md")
           :image-beside #:image{:src "/assets/lambda-logo.svg"
                                 :src-dark "/assets/lambda-logo-dark-mode.svg"
-                                :alt "Lambda Logo"}}
+                                :alt "Lambda Logo"}
+          :default-order 1}
    #:post{:id (u/mk-uuid)
           :page :home
           :css-class "golden-island"
@@ -115,7 +123,8 @@
           :md-content (slurp-md "home" "golden-island.md")
           :image-beside #:image{:src "/assets/4suits.svg"
                                 :src-dark "/assets/4suits-dark-mode.svg"
-                                :alt "4 suits of a deck"}}
+                                :alt "4 suits of a deck"}
+          :default-order 2}
    #:post{:id (u/mk-uuid)
           :page :home
           :css-class "magic"
@@ -123,7 +132,8 @@
           :md-content (slurp-md "home" "magic.md")
           :image-beside #:image{:src "/assets/binary.svg"
                                 :src-dark "/assets/binary-dark-mode.svg"
-                                :alt "Love word written in base 2"}}])
+                                :alt "Love word written in base 2"}
+          :default-order 3}])
 
 (def posts
   (concat home-posts apply-posts about-posts blog-posts))


### PR DESCRIPTION
## Closes #185

- [x] Pull posts with `:post/default-order` included.
- [x] Display posts sorted by `:post/default-order`.
    - [x] Blog posts are sorted by `:post/creation-date` instead.

This pull request does not yet allow new posts to have custom positions. New posts are still automatically added to the end by default.