### PR TITLE
Remove obsolete page config logic

### DIFF
--- a/client/common/src/flybot/client/common/db/event.cljs
+++ b/client/common/src/flybot/client/common/db/event.cljs
@@ -24,17 +24,14 @@
 
 (rf/reg-event-fx
  :fx.http/all-success
- (fn [{:keys [db]} [_ {:keys [pages posts users]}]]
+ (fn [{:keys [db]} [_ {:keys [posts users]}]]
    (let [user (-> users :auth :logged)]
-     {:db (merge db {:app/pages (->> pages
-                                     :all
-                                     (utils/to-indexed-maps :page/name))
-                     :app/posts (->> posts
+     {:db (merge db {:app/posts (->> posts
                                      :all
                                      (map #(assoc % :post/mode :read))
                                      (utils/to-indexed-maps :post/id))
                      :app/user  (when (seq user) user)})
-      :fx [[:fx.log/message "Got all the posts and all the Pages configurations."]
+      :fx [[:fx.log/message "Got all the posts."]
            [:fx.log/message [(if (seq user)
                                (str "User " (:user/name user) " logged in.")
                                (str "No user logged in"))]]]})))

--- a/client/mobile/src/flybot/client/mobile/core/db/event.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/db/event.cljs
@@ -27,12 +27,9 @@
                  db
                  :navigator/ref @nav/nav-ref)
     :http-xhrio {:method          :post
-                 :uri             (base-uri "/pages/all")
+                 :uri             (base-uri "/posts/all")
                  :headers {:cookie (:user/cookie db)}
-                 :params {:pages
-                          {(list :all :with [])
-                           [{:page/name '?}]}
-                          :posts
+                 :params {:posts
                           {(list :all :with [])
                            [{:post/id '?
                              :post/page '?

--- a/client/web/src/flybot/client/web/core/db/event.cljs
+++ b/client/web/src/flybot/client/web/core/db/event.cljs
@@ -80,11 +80,8 @@
                    :user/mode        :reader
                    :nav/navbar-open? false)
       :http-xhrio {:method          :post
-                   :uri             "/pages/all"
-                   :params {:pages
-                            {(list :all :with [])
-                             [{:page/name '?}]}
-                            :posts
+                   :uri             "/posts/all"
+                   :params {:posts
                             {(list :all :with [])
                              [{:post/id '?
                                :post/page '?

--- a/client/web/test/flybot/client/web/core/db_test.cljs
+++ b/client/web/test/flybot/client/web/core/db_test.cljs
@@ -27,7 +27,7 @@
   ;; Mock success http request
   (rf/reg-fx :http-xhrio
              (fn [_]
-               (rf/dispatch [:fx.http/all-success s/init-pages-and-posts])))
+               (rf/dispatch [:fx.http/all-success s/init-data])))
   ;; Initialize db
   (rf/dispatch [:evt.app/initialize]))
 
@@ -57,7 +57,7 @@
      ;; Mock success http request
      (rf/reg-fx :http-xhrio
                 (fn [_]
-                  (rf/dispatch [:fx.http/all-success s/init-pages-and-posts])))
+                  (rf/dispatch [:fx.http/all-success s/init-data])))
      ;; Initialize db
      (rf/dispatch [:evt.app/initialize])
      (testing "Initial db state is accurate in case no server error."
@@ -67,7 +67,6 @@
        (is (= :reader @mode))
        (is (= false @navbar-open?))
        (is (= 2 (-> @posts count)))
-       (is (= [:home :apply] (-> @re-frame.db/app-db :app/pages keys)))
        (is (= s/bob-user @user))))))
 
 (deftest theme

--- a/client/web/test/flybot/client/web/core/dom/common/link_test.cljs
+++ b/client/web/test/flybot/client/web/core/dom/common/link_test.cljs
@@ -21,7 +21,7 @@
   ;; Mock success http request
   (rf/reg-fx :http-xhrio
              (fn [_]
-               (rf/dispatch [:fx.http/all-success s/init-pages-and-posts])))
+               (rf/dispatch [:fx.http/all-success s/init-data])))
   ;; Initialize db
   (rf/dispatch [:evt.app/initialize]))
 

--- a/client/web/test/flybot/client/web/core/dom/page/post_test.cljs
+++ b/client/web/test/flybot/client/web/core/dom/page/post_test.cljs
@@ -19,7 +19,7 @@
          :post/page :blog
          :post/md-content "# [Hi there,](https://www.flybot.sg) Henlo!"))
 
-(def init-pages-and-posts
+(def init-data
   {:posts {:all [post-1]}
    :pages {:all [{:page/name :home}
                  {:page/name :apply}]}
@@ -38,7 +38,7 @@
   ;; Mock success http request
   (rf/reg-fx :http-xhrio
              (fn [_]
-               (rf/dispatch [:fx.http/all-success init-pages-and-posts])))
+               (rf/dispatch [:fx.http/all-success init-data])))
   ;; Initialize db
   (rf/dispatch [:evt.app/initialize]))
 

--- a/client/web/test/flybot/client/web/core/router_test.cljs
+++ b/client/web/test/flybot/client/web/core/router_test.cljs
@@ -24,7 +24,7 @@
   ;; Mock success http request
   (rf/reg-fx :http-xhrio
              (fn [_]
-               (rf/dispatch [:fx.http/all-success s/init-pages-and-posts])))
+               (rf/dispatch [:fx.http/all-success s/init-data])))
   ;; Initialize db
   (rf/dispatch [:evt.app/initialize]))
 

--- a/common/src/flybot/common/validation.cljc
+++ b/common/src/flybot/common/validation.cljc
@@ -56,15 +56,6 @@
       (mu/assoc :post/last-editor author-schema)
       (mu/update-properties assoc :preserve-required true)))
 
-(def page-schema
-  [:map {:closed true}
-   [:page/name :keyword]])
-
-(def page-schema-create
-  "The difference with `page-schema` is that:
-     - the required keys won't be affected by all-keys-optional."
-  (mu/update-properties page-schema assoc :preserve-required true))
-
 (defn all-keys-optional
   "Walk through the given `schema` and set all keys to optional."
   [schema]
@@ -91,11 +82,6 @@
       [:all [:=> [:cat] [:vector post-schema]]]
       [:new-post [:=> [:cat post-schema-create] post-schema]]
       [:removed-post [:=> [:cat :uuid :string] post-schema]]]]
-    [:pages
-     [:map
-      [:page [:=> [:cat :keyword] page-schema]]
-      [:all [:=> [:cat] [:vector page-schema]]]
-      [:new-page [:=> [:cat page-schema-create] page-schema]]]]
     [:users
      [:map
       [:user [:=> [:cat :string] user-schema]]
@@ -137,9 +123,3 @@
         (update :post/id (if temp-id? (constantly (u/mk-uuid)) identity))
         (assoc date-field (u/mk-date))
         (assoc-in [writer-field :user/id] user-id))))
-
-(defn prepare-page
-  "Given the `page` from the page form,
-      returns a page matching server format requirements."
-  [page]
-  (dissoc page :page/mode))

--- a/common/test/flybot/common/test_sample_data.cljc
+++ b/common/test/flybot/common/test_sample_data.cljc
@@ -2,11 +2,6 @@
   "Sample data that can be used in both backend and frontend tests."
   (:require [flybot.common.utils :as u]))
 
-;;---------- Pages ----------
-
-(def home-page {:page/name :home})
-(def apply-page {:page/name :apply})
-
 ;;---------- Users ----------
 
 (def bob-id "bob-id")
@@ -84,7 +79,6 @@
          :creation-date post-3-create-date
          :author        #:user{:id bob-id}})
 
-(def init-pages-and-posts
+(def init-data
   {:posts {:all [post-1 post-2]}
-   :pages {:all [home-page apply-page]}
    :users {:auth {:logged bob-user}}})

--- a/server/src/flybot/server/core/handler.clj
+++ b/server/src/flybot/server/core/handler.clj
@@ -122,11 +122,6 @@
                               :middleware [[auth/authorization-middleware [:editor]]]}]
             ["/removed-post" {:post       ring-handler
                               :middleware [[auth/authorization-middleware [:editor]]]}]]
-           ["/pages"
-            ["/all"          {:post ring-handler}]
-            ["/page"         {:post ring-handler}]
-            ["/new-page"     {:post       ring-handler
-                              :middleware [[auth/authorization-middleware [:editor]]]}]]
            ["/users"
             ["/logout"         {:get (auth/logout-handler client-root-path)}]
             ["/all"            {:post ring-handler}]

--- a/server/src/flybot/server/core/handler/operation/db.clj
+++ b/server/src/flybot/server/core/handler/operation/db.clj
@@ -49,11 +49,6 @@
    {:db/ident :post/default-order
     :db/valueType :db.type/long}])
 
-(def page-schema
-  [{:db/ident :page/name
-    :db/valueType :db.type/keyword
-    :db/unique :db.unique/identity}])
-
 (def role-schema
   [{:db/ident :role/name
     :db/valueType :db.type/keyword
@@ -81,39 +76,11 @@
    (concat
     image-schema
     post-schema
-    page-schema
     role-schema
     user-schema)))
 
 (def initial-datalevin-schema
   (datomic->datalevin initial-datomic-schema))
-
-;;---------- Page ----------
-
-(def page-pull-pattern
-  [:page/name])
-
-(defn get-page
-  [db page-name]
-  (->> (d/q
-        '[:find (pull ?page pull-pattern)
-          :in $ ?page-name pull-pattern
-          :where [?page :page/name ?page-name]]
-        db
-        page-name
-        page-pull-pattern)
-       ffirst))
-
-(defn get-all-pages
-  [db]
-  (->> (d/q
-        '[:find (pull ?page pull-pattern)
-          :in $ pull-pattern
-          :where [?page :page/name]]
-        db
-        page-pull-pattern)
-       (map first)
-       vec))
 
 ;;---------- User ----------
 
@@ -154,8 +121,7 @@
           :where [?user :user/id]]
         db
         user-pull-pattern)
-       (map first)
-       vec))
+       (mapv first)))
 
 ;;---------- Post ----------
 
@@ -192,5 +158,17 @@
           :where [?posts :post/id]]
         db
         post-pull-pattern)
-       (map first)
-       vec))
+       (mapv first)))
+
+(defn get-all-posts-of
+  "Get all posts from `page-name`."
+  [db page-name]
+  (->> (d/q
+        '[:find (pull ?posts pull-pattern)
+          :in $ ?page pull-pattern
+          :where
+          [?posts :post/page ?page]]
+        db
+        page-name
+        post-pull-pattern)
+       (mapv first)))

--- a/server/src/flybot/server/core/init_data.clj
+++ b/server/src/flybot/server/core/init_data.clj
@@ -138,19 +138,5 @@
 (def posts
   (concat home-posts apply-posts about-posts blog-posts))
 
-(def pages
-  [#:page{:name :home
-          :sorting-method #:sort{:type :creation-date
-                                 :direction :ascending}}
-   #:page{:name :apply
-          :sorting-method #:sort{:type :creation-date
-                                 :direction :ascending}}
-   #:page{:name :about
-          :sorting-method #:sort{:type :creation-date
-                                 :direction :ascending}}
-   #:page{:name :blog
-          :sorting-method #:sort{:type :creation-date
-                                 :direction :ascending}}])
-
 (def init-data
-  (concat posts pages users))
+  (concat posts users))

--- a/server/test/flybot/server/core/handler/operation_test.clj
+++ b/server/test/flybot/server/core/handler/operation_test.clj
@@ -9,7 +9,6 @@
             [robertluo.fun-map :refer [halt! touch]]))
 
 (def test-data [s/post-1 s/post-2
-                s/home-page s/apply-page
                 s/bob-user s/alice-user])
 (def test-system
   (-> (sys/system-config :test)
@@ -25,57 +24,56 @@
 (use-fixtures :once system-fixture)
 
 (deftest update-post-orders-with-test
-  (let [posts [{:post/id s/post-1-id :post/default-order 0}
-               {:post/id s/post-2-id :post/default-order 1}
-               {:post/id s/post-3-id :post/default-order 2}]
-        post-2 {:post/id s/post-2-id}
-        post-4 {:post/id s/post-4-id}
-        update-with-new-post
-        #(sut/update-post-orders-with posts % :new-post)
-        update-with-removed-post
-        #(sut/update-post-orders-with posts % :removed-post)]
+  (let [posts [{:post/id s/post-1-id :post/default-order 0 :post/page :home}
+               {:post/id s/post-2-id :post/default-order 1 :post/page :home}
+               {:post/id s/post-3-id :post/default-order 2 :post/page :home}]
+        post-2 {:post/id s/post-2-id :post/default-order 2 :post/page :home}
+        post-4 {:post/id s/post-4-id :post/default-order 2 :post/page :home}
+        update-with-new-post #(sut/update-post-orders-with posts % :new-post)
+        update-with-removed-post #(sut/update-post-orders-with posts % :removed-post)]
     (testing "Returns only posts whose default orders need to be updated:"
       (testing "New post:"
         (testing "`nil` order."
-          (is (= [{:post/id s/post-4-id :post/default-order 3}]
+          (is (= [{:post/id s/post-4-id :post/default-order 3 :post/page :home}]
                  (update-with-new-post (dissoc post-4 :post/default-order)))))
         (testing "Normal order."
-          (is (= [{:post/id s/post-4-id :post/default-order 2}
-                  {:post/id s/post-3-id :post/default-order 3}]
+          (is (= [{:post/id s/post-4-id :post/default-order 2 :post/page :home}
+                  {:post/id s/post-3-id :post/default-order 3 :post/page :home}]
                  (update-with-new-post (assoc post-4 :post/default-order 2)))))
         (testing "Out-of-bounds order."
-          (is (= [{:post/id s/post-4-id :post/default-order 3}]
+          (is (= [{:post/id s/post-4-id :post/default-order 3 :post/page :home}]
                  (update-with-new-post (assoc post-4 :post/default-order 4))))))
       (testing "Edited post:"
         (testing "`nil` order."
-          (is (= [{:post/id s/post-3-id :post/default-order 1}
-                  {:post/id s/post-2-id :post/default-order 2}]
+          (is (= [{:post/id s/post-3-id :post/default-order 1 :post/page :home}
+                  {:post/id s/post-2-id :post/default-order 2 :post/page :home}]
                  (update-with-new-post (dissoc post-2 :post/default-order)))))
         (testing "Moved toward zeroth."
-          (is (= [{:post/id s/post-2-id :post/default-order 0}
-                  {:post/id s/post-1-id :post/default-order 1}]
+          (is (= [{:post/id s/post-2-id :post/default-order 0 :post/page :home}
+                  {:post/id s/post-1-id :post/default-order 1 :post/page :home}]
                  (update-with-new-post (assoc post-2 :post/default-order 0)))))
         (testing "Same order as before, no edits."
           (is (= []
                  (update-with-new-post (assoc post-2 :post/default-order 1)))))
         (testing "Same order with edit."
           (is (= [{:post/id s/post-2-id
+                   :post/page :home
                    :post/default-order 1
                    :post/md-content "# a"}]
                  (update-with-new-post (assoc post-2
                                   :post/default-order 1
                                   :post/md-content "# a")))))
         (testing "Moved toward end."
-          (is (= [{:post/id s/post-3-id :post/default-order 1}
-                  {:post/id s/post-2-id :post/default-order 2}]
+          (is (= [{:post/id s/post-3-id :post/default-order 1 :post/page :home}
+                  {:post/id s/post-2-id :post/default-order 2 :post/page :home}]
                  (update-with-new-post (assoc post-2 :post/default-order 2)))))
         (testing "Out-of-bounds order."
-          (is (= [{:post/id s/post-3-id :post/default-order 1}
-                  {:post/id s/post-2-id :post/default-order 2}]
+          (is (= [{:post/id s/post-3-id :post/default-order 1 :post/page :home}
+                  {:post/id s/post-2-id :post/default-order 2 :post/page :home}]
                  (update-with-new-post (assoc post-2 :post/default-order 4))))))
       (testing "Removed post:"
         (testing "Post found."
-          (is (= [{:post/id s/post-3-id :post/default-order 1}]
+          (is (= [{:post/id s/post-3-id :post/default-order 1 :post/page :home}]
                  (update-with-removed-post post-2))))
         (testing "No post found."
           (is (= []


### PR DESCRIPTION
Closes #187
---

- remove obsolete backend route, validation schema, pull pattern fields
- only provide posts from the relevant page to `update-post-orders-with` and update tests
- add `get-all-posts-of` to only fetch posts of a given `page-name`