### PR TITLE
Use distinct timestamps in tests

### DIFF
--- a/common/src/flybot/common/validation.cljc
+++ b/common/src/flybot/common/validation.cljc
@@ -13,7 +13,7 @@
 ;;---------- Validation Schemas ----------
 
 (def author-schema
-  [:map
+  [:map {:closed true}
    [:user/id :string]])
 
 (def user-schema

--- a/common/test/flybot/common/test_sample_data.cljc
+++ b/common/test/flybot/common/test_sample_data.cljc
@@ -2,14 +2,25 @@
   "Sample data that can be used in both backend and frontend tests."
   (:require [flybot.common.utils :as u]))
 
+;;---------- Dates ----------
+
+(def dates
+  [#inst "2023-01-01"
+   #inst "2023-01-02"
+   #inst "2023-01-03"
+   #inst "2023-01-04"
+   #inst "2023-01-05"
+   #inst "2023-01-06"
+   #inst "2023-01-07"])
+
 ;;---------- Users ----------
 
 (def bob-id "bob-id")
 (def alice-id "alice-id")
 (def joshua-id "joshua-id")
-(def bob-date-granted (u/mk-date))
-(def alice-date-granted (u/mk-date))
-(def joshua-date-granted (u/mk-date))
+(def bob-date-granted (nth dates 0))
+(def alice-date-granted (nth dates 1))
+(def joshua-date-granted (nth dates 2))
 
 (def bob-user
   #:user{:id "bob-id"
@@ -44,10 +55,10 @@
 (def post-3-id (u/mk-uuid))
 (def post-4-id (u/mk-uuid))
 
-(def post-1-create-date (u/mk-date))
-(def post-1-edit-date (u/mk-date))
-(def post-2-create-date (u/mk-date))
-(def post-3-create-date (u/mk-date))
+(def post-1-create-date (nth dates 3))
+(def post-1-edit-date (nth dates 4))
+(def post-2-create-date (nth dates 5))
+(def post-3-create-date (nth dates 6))
 
 (def post-1
   #:post{:id             post-1-id

--- a/server/src/flybot/server/core/handler/operation.clj
+++ b/server/src/flybot/server/core/handler/operation.clj
@@ -56,7 +56,7 @@
         page (:post/page post)
         posts (-> db
                   (db/get-all-posts-of page)
-                  (update-post-orders-with full-post :new-post))]
+                  (update-post-orders-with post :new-post))]
     {:response full-post
      :effects  {:db {:payload posts}}}))
 

--- a/server/src/flybot/server/core/handler/operation.clj
+++ b/server/src/flybot/server/core/handler/operation.clj
@@ -23,31 +23,37 @@
 ;;---------- Ops with effects ----------
 
 (defn update-post-orders-with
-  "Given the `posts` of a page and a `post` with a new default-order,
-   Returns all the posts of that page that have had their default-order affected.
-   - post: new/removed post
-   - option: type of action affetcing the post order: `new-post` or `removed-post`"
+  "Given the `posts` of a page and a new/edited/removed `post`, returns all
+  posts whose default orders need to be updated. If `post` is a new or edited
+  post, includes `post` with the correct default order as well.
+
+  - `post`: New/edited/removed post
+  - `option`: Type of action for the given post. Must be :new-post if `post`
+  is new/edited, or :removed-post if `post` is removed."
   [posts {:post/keys [id default-order] :as post} option]
-  (let [page-posts (into #{} posts)
-        other-posts (->> page-posts
-                         (filter #(not= id (:post/id %)))
+  (let [existing-post (->> posts
+                           (filter #(= id (:post/id %)))
+                           first)
+        other-posts (->> posts
+                         (remove #(= id (:post/id %)))
+                         (map #(select-keys % [:post/id :post/default-order]))
                          (sort-by :post/default-order))
         [posts-before posts-after] (if default-order
                                      (split-at default-order other-posts)
                                      [other-posts []])
         updated-posts (->>
-                       (condp = option
+                       (case option
                          :new-post (concat posts-before [post] posts-after)
                          :removed-post other-posts
                          [])
                        (map-indexed
                         (fn [i post] (assoc post :post/default-order i)))
-                       (remove page-posts))]
+                       (remove (into #{existing-post} other-posts)))]
     updated-posts))
 
 (defn add-post
-  "Add the post to the DB.
-   Returns the post with the full author/editor profile included."
+  "Add the post to the DB with only the author/editor IDs included.
+   Returns the post with the full author/editor profiles included."
   [db post]
   (let [author (db/get-user db (-> post :post/author :user/id))
         editor (db/get-user db (-> post :post/last-editor :user/id))

--- a/server/src/flybot/server/core/handler/operation/db.clj
+++ b/server/src/flybot/server/core/handler/operation/db.clj
@@ -51,8 +51,7 @@
 
 (def role-schema
   [{:db/ident :role/name
-    :db/valueType :db.type/keyword
-    :db/unique :db.unique/identity}
+    :db/valueType :db.type/keyword}
    {:db/ident :role/date-granted
     :db/valueType :db.type/instant}])
 

--- a/server/test/flybot/server/core/handler/operation_test.clj
+++ b/server/test/flybot/server/core/handler/operation_test.clj
@@ -62,8 +62,8 @@
                    :post/default-order 1
                    :post/md-content "# a"}]
                  (update-with-new-post (assoc post-2
-                                  :post/default-order 1
-                                  :post/md-content "# a")))))
+                                              :post/default-order 1
+                                              :post/md-content "# a")))))
         (testing "Moved toward end."
           (is (= [{:post/id s/post-3-id :post/default-order 1}
                   {:post/id s/post-2-id :post/default-order 2}]
@@ -87,7 +87,7 @@
             post-out (assoc s/post-3 :post/author s/bob-user)]
         (is (= {:response post-out
                 :effects {:db {:payload
-                               [(assoc post-out :post/default-order 2)]}}}
+                               [(assoc post-in :post/default-order 2)]}}}
                (sut/add-post (d/db db-conn) post-in)))))))
 
 (deftest delete-post

--- a/server/test/flybot/server/core/handler/operation_test.clj
+++ b/server/test/flybot/server/core/handler/operation_test.clj
@@ -95,16 +95,14 @@
     (testing "User is admin so returns post delete effects."
       (is (= {:response {:post/id s/post-1-id}
               :effects  {:db {:payload [[:db.fn/retractEntity [:post/id s/post-1-id]]
-                                        (assoc s/post-2
-                                               :post/author s/bob-user
-                                               :post/default-order 0)]}}}
+                                        #:post{:id s/post-2-id
+                                               :default-order 0}]}}}
              (sut/delete-post (d/db db-conn) s/post-1-id s/bob-id))))
     (testing "User is author of post so returns post delete effects."
       (is (= {:response {:post/id s/post-1-id}
               :effects  {:db {:payload [[:db.fn/retractEntity [:post/id s/post-1-id]]
-                                        (assoc s/post-2
-                                               :post/author s/bob-user
-                                               :post/default-order 0)]}}}
+                                        #:post{:id s/post-2-id
+                                               :default-order 0}]}}}
              (sut/delete-post (d/db db-conn) s/post-1-id s/alice-id))))
     (testing "User is not author nor admin so returns error map."
       (is (= {:error {:type      :authorization

--- a/server/test/flybot/server/core/handler_test.clj
+++ b/server/test/flybot/server/core/handler_test.clj
@@ -79,7 +79,7 @@
                               #:post{:id s/post-3-id}}}
               :effects-desc [{:db
                               {:payload
-                               [(assoc post-out :post/default-order 2)]}}]
+                               [(assoc post-in :post/default-order 2)]}}]
               :session      {}}
              (saturn-handler {:body-params {:posts
                                             {(list :new-post :with [post-in])
@@ -246,8 +246,12 @@
     (let [resp (http-request "/users/all"
                              {:users
                               {(list :all :with [])
-                               [{:user/id '?}]}})]
-      (is (= [{:user/id s/alice-id} {:user/id s/bob-id}]
+                               [{:user/id '?
+                                 :user/name '?
+                                 :user/roles [{:role/name '?
+                                               :role/date-granted '?}]}]}})]
+      (is (= [(select-keys s/alice-user [:user/id :user/name :user/roles])
+              (select-keys s/bob-user [:user/id :user/name :user/roles])]
              (-> resp :body :users :all)))))
   (testing "Execute a request for a user."
     (let [resp (http-request "/users/user"


### PR DESCRIPTION
## Closes #178

- [ ] Use hard-coded timestamps that differ by at least one day in back-end tests.

    Some tests that previously passed now fail with visible timestamp discrepancies.