### PR TITLE
189 re frame db posts order update

### DIFF
--- a/client/web/test/flybot/client/web/core/db_test.cljs
+++ b/client/web/test/flybot/client/web/core/db_test.cljs
@@ -8,8 +8,7 @@
             [flybot.client.web.core.router :as router]
             [flybot.common.test-sample-data :as s]
             [flybot.common.utils :as utils]
-            [re-frame.core :as rf]
-            [re-frame.db :as rf.db]))
+            [re-frame.core :as rf]))
 
 ;; ---------- Fixtures ----------
 
@@ -191,7 +190,8 @@
            new-post-form (rf/subscribe [:subs/pattern '{:form/fields ?x}])
            posts         (rf/subscribe [:subs.post/posts :home])
            new-post      (assoc empty-post
-                                :post/md-content "#New Content 1")]
+                                :post/md-content "#New Content 1"
+                                :post/default-order 2)]
      ;;---------- AUTOFILL POST FORM
      ;; Toggle mode
        (rf/dispatch [:evt.post/toggle-edit-mode temp-id])

--- a/client/web/test/flybot/client/web/core/router_test.cljs
+++ b/client/web/test/flybot/client/web/core/router_test.cljs
@@ -39,7 +39,8 @@
                        :post/page :blog
                        :post/mode :edit
                        :post/author {:user/id "bob-id" :user/name "Bob"}
-                       :post/creation-date (utils/mk-date)}
+                       :post/creation-date s/post-1-create-date
+                       :post/default-order 0}
            post-mode (rf/subscribe [:subs/pattern
                                     {:app/posts {temp-id '{:post/mode ?x}}}])
            posts (rf/subscribe [:subs.post/posts :blog])

--- a/common/src/flybot/common/utils.cljc
+++ b/common/src/flybot/common/utils.cljc
@@ -24,3 +24,26 @@
   "Toggles 2 values."
   [cur [v1 v2]]
   (if (= cur v1) v2 v1))
+
+(defn update-post-orders-with
+  "Given the `posts` of a page and a `post` with a new default-order,
+   Returns all the posts of that page that have had their default-order affected.
+   - post: new/removed post
+   - option: type of action affetcing the post order: `new-post` or `removed-post`"
+  [posts {:post/keys [id default-order] :as post} option]
+  (let [page-posts (into #{} posts)
+        other-posts (->> page-posts
+                         (filter #(not= id (:post/id %)))
+                         (sort-by :post/default-order))
+        [posts-before posts-after] (if default-order
+                                     (split-at default-order other-posts)
+                                     [other-posts []])
+        updated-posts (->>
+                       (condp = option
+                         :new-post (concat posts-before [post] posts-after)
+                         :removed-post other-posts
+                         [])
+                       (map-indexed
+                        (fn [i post] (assoc post :post/default-order i)))
+                       (remove page-posts))]
+    updated-posts))

--- a/common/test/flybot/common/utils_test.cljc
+++ b/common/test/flybot/common/utils_test.cljc
@@ -1,0 +1,59 @@
+(ns flybot.common.utils-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [flybot.common.test-sample-data :as s]
+            [flybot.common.utils :as sut]))
+
+(deftest update-post-orders-with-test
+  (let [posts [{:post/id s/post-1-id :post/default-order 0}
+               {:post/id s/post-2-id :post/default-order 1}
+               {:post/id s/post-3-id :post/default-order 2}]
+        post-2 {:post/id s/post-2-id}
+        post-4 {:post/id s/post-4-id}
+        update-with-new-post #(sut/update-post-orders-with posts % :new-post)
+        update-with-removed-post #(sut/update-post-orders-with posts % :removed-post)]
+    (testing "Returns only posts whose default orders need to be updated:"
+      (testing "New post:"
+        (testing "`nil` order."
+          (is (= [{:post/id s/post-4-id :post/default-order 3}]
+                 (update-with-new-post post-4))))
+        (testing "Normal order."
+          (is (= [{:post/id s/post-4-id :post/default-order 2}
+                  {:post/id s/post-3-id :post/default-order 3}]
+                 (update-with-new-post (assoc post-4 :post/default-order 2)))))
+        (testing "Out-of-bounds order."
+          (is (= [{:post/id s/post-4-id :post/default-order 3}]
+                 (update-with-new-post (assoc post-4 :post/default-order 4))))))
+      (testing "Edited post:"
+        (testing "`nil` order."
+          (is (= [{:post/id s/post-3-id :post/default-order 1}
+                  {:post/id s/post-2-id :post/default-order 2}]
+                 (update-with-new-post post-2))))
+        (testing "Moved toward zeroth."
+          (is (= [{:post/id s/post-2-id :post/default-order 0}
+                  {:post/id s/post-1-id :post/default-order 1}]
+                 (update-with-new-post (assoc post-2 :post/default-order 0)))))
+        (testing "Same order as before, no edits."
+          (is (= []
+                 (update-with-new-post (assoc post-2 :post/default-order 1)))))
+        (testing "Same order with edit."
+          (is (= [{:post/id s/post-2-id
+                   :post/default-order 1
+                   :post/md-content "# a"}]
+                 (update-with-new-post (assoc post-2
+                                              :post/default-order 1
+                                              :post/md-content "# a")))))
+        (testing "Moved toward end."
+          (is (= [{:post/id s/post-3-id :post/default-order 1}
+                  {:post/id s/post-2-id :post/default-order 2}]
+                 (update-with-new-post (assoc post-2 :post/default-order 2)))))
+        (testing "Out-of-bounds order."
+          (is (= [{:post/id s/post-3-id :post/default-order 1}
+                  {:post/id s/post-2-id :post/default-order 2}]
+                 (update-with-new-post (assoc post-2 :post/default-order 4))))))
+      (testing "Removed post:"
+        (testing "Post found."
+          (is (= [{:post/id s/post-3-id :post/default-order 1}]
+                 (update-with-removed-post post-2))))
+        (testing "No post found."
+          (is (= []
+                 (update-with-removed-post post-4))))))))


### PR DESCRIPTION
Closes #189
---

- move `update-post-orders-with` to `flybot.common.utils` namespace to be accessible in both backend and frontend
- re-frame events `:evt.post/add-post` and `:evt.post/delete-post` now also take care of re-ordering the posts and update the re-frame db.

###Note

As for now, there is no form field to customise the `post/default-order` so:
- new post is given the highest post default value (so appears last)
- edit post keeps his post default value so no order changed is made
- remove post triggers proper reordering