### PR TITLE
Uses non-defined custom status

### DIFF
--- a/server/src/flybot/server/core/handler/middleware.clj
+++ b/server/src/flybot/server/core/handler/middleware.clj
@@ -10,17 +10,16 @@
           :data (ex-data exception)
           :uri (:uri request)}})
 
-;;TODO: error not thrown if comes from redirect?
 (def exception-middleware
   "When a ex-data :type is matched, create a handler with custom status and error message."
   (exception/create-exception-middleware
-   {:pattern/schema            (partial handler 407 "Invalid pattern provided")
-    :user/login                (partial handler 408 "Cannot login because user does not exist")
-    :user/delete               (partial handler 409 "Cannot delete because user does not exist")
-    :user.admin/not-found      (partial handler 414 "User does not exist")
-    :user.admin/already-admin  (partial handler 415 "User is already admin")
-    :api.google/fetch-user     (partial handler 412 "Could not fecth google user info")
-    :authorization             (partial handler 413 "User does not have the required permission.")
+   {:pattern/schema            (partial handler 470 "Invalid pattern provided")
+    :user/login                (partial handler 471 "Cannot login because user does not exist")
+    :user/delete               (partial handler 472 "Cannot delete because user does not exist")
+    :user.admin/not-found      (partial handler 473 "User does not exist")
+    :user.admin/already-admin  (partial handler 474 "User is already admin")
+    :api.google/fetch-user     (partial handler 475 "Could not fecth google user info")
+    :authorization             (partial handler 476 "User does not have the required permission.")
     ::exception/default        (partial handler 500 "Default")}))
 
 (defn ring-cfg

--- a/server/test/flybot/server/core/handler_test.clj
+++ b/server/test/flybot/server/core/handler_test.clj
@@ -126,20 +126,20 @@
       (is (= 204 (-> resp :status)))))
   (testing "Invalid pattern so returns error 407."
     (let [resp (http-request "/posts/post" {:invalid-key '?})]
-      (is (= 407 (-> resp :status)))))
+      (is (= 470 (-> resp :status)))))
   (testing "Cannot delete user who does not exist so returns 409."
     (with-redefs [auth/has-permission? (constantly true)]
       (let [resp (http-request "/users/removed-user"
                                {:users
                                 {(list :removed-user :with [s/joshua-id])
                                  {:user/id '?}}})]
-        (is (= 409 (-> resp :status))))))
+        (is (= 472 (-> resp :status))))))
   (testing "User does not have permission so returns 413."
     (let [resp (http-request "/posts/new-post"
                              {:posts
                               {(list :new-post :with [::POST])
                                {:post/id '?}}})]
-      (is (= 413 (-> resp :status)))))
+      (is (= 476 (-> resp :status)))))
   (testing "User is not found so returns 414."
     (with-redefs [auth/has-permission? (constantly true)]
       (let [resp (http-request "/users/new-role/admin"
@@ -148,7 +148,7 @@
                                  {(list :admin :with ["unknown.email@basecity.com"])
                                   {:user/roles [{:role/name '?
                                                  :role/date-granted '?}]}}}})]
-        (is (= 414 (-> resp :status))))))
+        (is (= 473 (-> resp :status))))))
   (testing "User is already admin so returns 415."
     (with-redefs [auth/has-permission? (constantly true)]
       (let [bob-email (:user/email s/bob-user)
@@ -158,7 +158,7 @@
                                  {(list :admin :with [bob-email])
                                   {:user/roles [{:role/name '?
                                                  :role/date-granted '?}]}}}})]
-        (is (= 415 (-> resp :status))))))
+        (is (= 474 (-> resp :status))))))
 
   ;;---------- Posts
   (testing "Execute a request for all posts."


### PR DESCRIPTION
Closes #197
---

- use status from `470` onwards in `exception/create-exception-middleware` to prevent unexpected errors in the response's body.