### PR TITLE
Fix grant-role

### DIFF
--- a/server/src/flybot/server/core/handler/operation.clj
+++ b/server/src/flybot/server/core/handler/operation.clj
@@ -122,10 +122,9 @@
                    :user-email    email}}
           
           :else
-          (let [new-user (update user :user/roles conj {:role/name         role-to-grant
-                                                        :role/date-granted (utils/mk-date)})]
-            {:response new-user
-             :effects  {:db {:payload [new-user]}}}))))
+          (let [new-role {:role/name role-to-grant :role/date-granted (utils/mk-date)}]
+            {:response (update user :user/roles conj new-role)
+             :effects  {:db {:payload [(assoc user :user/roles [new-role])]}}}))))
 
 (def grant-admin-role
   #(grant-role % %2 :editor :admin))

--- a/server/test/flybot/server/core/handler/operation_test.clj
+++ b/server/test/flybot/server/core/handler/operation_test.clj
@@ -111,12 +111,13 @@
                         :requested-role :owner
                         :user-email editor-email}}
                (sut/grant-owner-role (d/db db-conn) editor-email)))))
-    (testing "User exits so returns user with new admin role effect."
+    (testing "User exits and has required role so returns user with new admin role effect."
       (with-redefs [utils/mk-date (constantly s/alice-date-granted)]
-        (let [updated-alice (update s/alice-user :user/roles conj {:role/name :admin
-                                                                   :role/date-granted (utils/mk-date)})]
+        (let [new-role {:role/name :admin :role/date-granted (utils/mk-date)}
+              updated-alice (update s/alice-user :user/roles conj new-role)
+              effects (assoc s/alice-user :user/roles [new-role])]
           (is (= {:response updated-alice
-                  :effects  {:db {:payload [updated-alice]}}}
+                  :effects  {:db {:payload [effects]}}}
                  (sut/grant-admin-role (d/db db-conn) (:user/email s/alice-user)))))))
     (testing "User does not exist so returns error map."
       (is (= {:error {:type    :user/not-found


### PR DESCRIPTION
Closes #209
---

- only the new role is returned in the effects in `grant-role` to prevent adding role twice to the db when a user gets a new role granted.