### PR TITLE
Make sorting menu display user's option correctly

### DIFF
--- a/client/web/src/flybot/client/web/core/dom/page/options.cljs
+++ b/client/web/src/flybot/client/web/core/dom/page/options.cljs
@@ -9,7 +9,7 @@
     [:label {:for "blog-sorting-options"} "Sort posts by:"]
     [:select#blog-sorting-options
      {:name "blog-sorting-options"
-      :value "[:date-created :descending]"
+      :defaultValue "[:date-created :descending]"
       :on-change #(rf/dispatch [:evt.page.form/set-blog-sorting-options
                                 (.. % -target -value)])}
      [:option


### PR DESCRIPTION
## Closes #212

- [x] Display the user's chosen sorting option correctly.
    (The menu was previously stuck displaying the default option.)