### PR TITLE
219-authorisation-fix

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,6 @@
 {:deps    {;; both frontend and backend
-           org.clojure/clojure                   {:mvn/version "1.11.1"}
+           org.clojure/clojure                   {:mvn/version "1.11.1"} 
+           camel-snake-kebab/camel-snake-kebab   {:mvn/version "0.4.3"}
            metosin/malli                         {:mvn/version "0.10.2"}
            metosin/reitit                        {:mvn/version "0.6.0"}
            metosin/muuntaja                      {:mvn/version "0.6.8"}

--- a/server/src/flybot/server/core/handler.clj
+++ b/server/src/flybot/server/core/handler.clj
@@ -118,25 +118,19 @@
           [["/posts"
             ["/all"          {:post ring-handler}]
             ["/post"         {:post ring-handler}]
-            ["/new-post"     {:post       ring-handler
-                              :middleware [[auth/authorization-middleware [:editor]]]}]
-            ["/removed-post" {:post       ring-handler
-                              :middleware [[auth/authorization-middleware [:editor]]]}]]
+            ["/new-post"     {:post ring-handler}]
+            ["/removed-post" {:post ring-handler}]]
            ["/users"
             ["/logout"         {:get (auth/logout-handler client-root-path)}]
             ["/all"            {:post ring-handler}]
             ["/user"           {:post ring-handler}]
             ["/logged-in-user" {:post ring-handler}]
-            ["/removed-user"   {:post       ring-handler
-                                :middleware [[auth/authorization-middleware [:owner]]]}]
+            ["/removed-user"   {:post ring-handler}]
             ["/new-role"
-             ["/admin" {:post       ring-handler
-                        :middleware [[auth/authorization-middleware [:owner]]]}]
-             ["/owner" {:post       ring-handler
-                        :middleware [[auth/authorization-middleware [:owner]]]}]]
+             ["/admin" {:post ring-handler}]
+             ["/owner" {:post ring-handler}]]
             ["/revoke-role"
-             ["/admin" {:post       ring-handler
-                        :middleware [[auth/authorization-middleware [:owner]]]}]]]
+             ["/admin" {:post ring-handler}]]]
            ["/oauth/google/success" {:get        ring-handler
                                      :middleware [[auth/authentification-middleware client-root-path]]}]
            ["/*" {:get {:handler index-handler}}]])

--- a/server/src/flybot/server/core/handler/auth.clj
+++ b/server/src/flybot/server/core/handler/auth.clj
@@ -1,25 +1,9 @@
 (ns flybot.server.core.handler.auth
   (:require [aleph.http :as http]
-            [cheshire.core :as cheshire]
+            [camel-snake-kebab.core :as csk]
+            [clojure.data.json :as json]
             [clj-commons.byte-streams :as bs]
-            [clojure.string :as str]
-            [clojure.walk :as walk]
             [reitit.oauth2 :as reitit]))
-
-(defn decode-key
-  "Converts a train case string/keyword into a snake case keyword."
-  [key]
-  (if (keyword? key)
-    (-> key name (str/replace "_" "-") keyword)
-    (keyword (str/replace key "_" "-"))))
-
-(defn to-snake-case
-  "Recursively transforms all map keys in coll with the transform-key fn."
-  [coll]
-  (letfn [(transform [x] (if (map? x)
-                           (into {} (map (fn [[k v]] [(decode-key k) v]) x))
-                           x))]
-    (walk/postwalk transform coll)))
 
 (defn google-api-fetch-user
   [access-tokens]
@@ -37,10 +21,9 @@
     (if (= status 200)
       (-> body
           bs/to-string
-          (cheshire/parse-string true)
-          to-snake-case)
-       {:error {:type           :api.google/fetch-user
-                :google-api-url google-api-url}})))
+          (json/read-str :key-fn csk/->kebab-case-keyword))
+      {:error {:type           :api.google/fetch-user
+               :google-api-url google-api-url}})))
 
 (defn redirect-302
   [resp landing-uri]

--- a/server/src/flybot/server/core/handler/operation.clj
+++ b/server/src/flybot/server/core/handler/operation.clj
@@ -176,7 +176,8 @@
                            (fn [post] (add-post db post)))
            :removed-post (with-role session :editor
                            (fn [post-id user-id] (delete-post db post-id user-id)))}
-   :users {:all          (fn [] (get-all-users db))
+   :users {:all          (with-role session :owner
+                           (fn [] (get-all-users db)))
            :user         (fn [id] (get-user db id))
            :removed-user (with-role session :owner
                            (fn [id] (delete-user db id)))

--- a/server/src/flybot/server/core/handler/operation.clj
+++ b/server/src/flybot/server/core/handler/operation.clj
@@ -1,6 +1,7 @@
 (ns flybot.server.core.handler.operation
-  (:require [flybot.server.core.handler.operation.db :as db]
-            [flybot.common.utils :as utils]))
+  (:require [flybot.common.utils :as utils]
+            [flybot.server.core.handler.auth :refer [with-role]]
+            [flybot.server.core.handler.operation.db :as db]))
 
 ;;---------- No Effect Ops ----------
 
@@ -171,13 +172,19 @@
   [db session]
   {:posts {:all          (fn [] (get-all-posts db))
            :post         (fn [post-id] (get-post db post-id))
-           :new-post     (fn [post] (add-post db post))
-           :removed-post (fn [post-id user-id] (delete-post db post-id user-id))}
+           :new-post     (with-role session :editor
+                           (fn [post] (add-post db post)))
+           :removed-post (with-role session :editor
+                           (fn [post-id user-id] (delete-post db post-id user-id)))}
    :users {:all          (fn [] (get-all-users db))
            :user         (fn [id] (get-user db id))
-           :removed-user (fn [id] (delete-user db id))
+           :removed-user (with-role session :owner
+                           (fn [id] (delete-user db id)))
            :auth         {:registered (fn [id email name picture] (register-user db id email name picture))
                           :logged     (fn [] (login-user db (:user-id session)))}
-           :new-role     {:admin (fn [email] (grant-admin-role db email))
-                          :owner (fn [email] (grant-owner-role db email))}
-           :revoked-role {:admin (fn [email] (revoke-admin-role db email))}}})
+           :new-role     {:admin (with-role session :owner
+                                   (fn [email] (grant-admin-role db email)))
+                          :owner (with-role session :owner
+                                   (fn [email] (grant-owner-role db email)))}
+           :revoked-role {:admin (with-role session :owner
+                                   (fn [email] (revoke-admin-role db email)))}}})

--- a/server/test/flybot/server/core/handler_test.clj
+++ b/server/test/flybot/server/core/handler_test.clj
@@ -260,16 +260,17 @@
 
   (testing "/users endpoints:"
     (testing "Execute a request for all users."
-      (let [resp (http-request "/users/all"
-                               {:users
-                                {(list :all :with [])
-                                 [{:user/id '?
-                                   :user/name '?
-                                   :user/roles [{:role/name '?
-                                                 :role/date-granted '?}]}]}})]
-        (is (= [(select-keys s/alice-user [:user/id :user/name :user/roles])
-                (select-keys s/bob-user [:user/id :user/name :user/roles])]
-               (-> resp :body :users :all)))))
+      (with-redefs [auth/has-permission? (constantly true)]
+        (let [resp (http-request "/users/all"
+                                 {:users
+                                  {(list :all :with [])
+                                   [{:user/id '?
+                                     :user/name '?
+                                     :user/roles [{:role/name '?
+                                                   :role/date-granted '?}]}]}})]
+          (is (= [(select-keys s/alice-user [:user/id :user/name :user/roles])
+                  (select-keys s/bob-user [:user/id :user/name :user/roles])]
+                 (-> resp :body :users :all))))))
     (testing "Execute a request for a user."
       (let [resp (http-request "/users/user"
                                {:users

--- a/server/test/flybot/server/core/handler_test.clj
+++ b/server/test/flybot/server/core/handler_test.clj
@@ -70,21 +70,21 @@
 
 (deftest saturn-handler
   (testing "Returns the proper saturn response."
-    (let [saturn-handler (:saturn-handler @a-test-system)
-          db-conn        (-> @a-test-system :db-conn :conn)
-          post-in        s/post-3
-          post-out       (assoc s/post-3 :post/author s/bob-user)]
-      (is (= {:response     {:posts
-                             {:new-post
-                              #:post{:id s/post-3-id}}}
-              :effects-desc [{:db
-                              {:payload
-                               [(assoc post-in :post/default-order 2)]}}]
-              :session      {}}
-             (saturn-handler {:body-params {:posts
-                                            {(list :new-post :with [post-in])
-                                             {:post/id '?}}}
-                              :db (d/db db-conn)}))))))
+    (with-redefs [auth/has-permission? (constantly true)]
+     (let [saturn-handler (:saturn-handler @a-test-system)
+           db-conn        (-> @a-test-system :db-conn :conn)
+           post-in        s/post-3]
+       (is (= {:response     {:posts
+                              {:new-post
+                               #:post{:id s/post-3-id}}}
+               :effects-desc [{:db
+                               {:payload
+                                [(assoc post-in :post/default-order 2)]}}]
+               :session      {}}
+              (saturn-handler {:body-params {:posts
+                                             {(list :new-post :with [post-in])
+                                              {:post/id '?}}}
+                               :db (d/db db-conn)})))))))
 
 (deftest ring-handler
   (testing "Returns the proper ring response."
@@ -137,7 +137,7 @@
     (testing "User does not have permission so returns 413."
       (let [resp (http-request "/posts/new-post"
                                {:posts
-                                {(list :new-post :with [::POST])
+                                {(list :new-post :with [s/post-3])
                                  {:post/id '?}}})]
         (is (= 476 (-> resp :status)))))
     (testing "User is not found so returns 414."


### PR DESCRIPTION
Closes #219

- move authorisation to `pullable-data` for safety reasons
- add authorisation check for route `/users/all`
- refactor auth