### PR TITLE
Make logo link to homepage

### DIFF
--- a/client/web/src/flybot/client/web/core/dom/header.cljs
+++ b/client/web/src/flybot/client/web/core/dom/header.cljs
@@ -32,9 +32,10 @@
   [:header.container
    [:div.top
     [:div
-     [:img.flybotlogo
-      {:alt "Flybot logo"
-       :src "/assets/flybot-logo.png"}]]
+     [internal-link :flybot/home
+      [:img.flybotlogo
+       {:alt "Flybot"
+        :src "/assets/flybot-logo.png"}]]]
     [svg/theme-logo]
     (when @(rf/subscribe [:subs/pattern '{:app/user ?x}])
       [svg/user-mode-logo])


### PR DESCRIPTION
## Closes #232

- [x] Users can now click the website logo to go back to the homepage.

- [x] The alt text description of the logo now simply reads "Flybot" to reflect the name of the website for accessibility.