### PR TITLE
Add notifications for successful actions

### DIFF
--- a/client/common/src/flybot/client/common/db/event.cljs
+++ b/client/common/src/flybot/client/common/db/event.cljs
@@ -334,12 +334,6 @@
                   :title title
                   :body body}))
 
-(rf/reg-event-fx
- :evt.app/toast-notify
- (fn [{:keys [db]} [_ notification]]
-   (let [theme (-> db :app/theme name)]
-     {:fx [[:fx.ui/toast-notify [notification {"theme" theme}]]]})))
-
 ;; ---------- Errors ----------
 
 (rf/reg-event-db

--- a/client/common/src/flybot/client/common/db/fx.cljs
+++ b/client/common/src/flybot/client/common/db/fx.cljs
@@ -16,26 +16,3 @@
  :fx.log/message
  (fn [messages]
    (.log js/console (apply str messages))))
-
-;; ---- Toast notifications ----
-
-(rf/reg-fx
- :fx.ui/toast-notify
- (fn [[{:notification/keys [type title body]} options]]
-   (let [type-options (case type
-                        :info {"type" "info"
-                               "autoClose" 10000
-                               "pauseOnHover" true}
-                        :success {"type" "success"
-                                  "autoClose" 5000
-                                  "pauseOnHover" false}
-                        :warning {"type" "warning"
-                                  "autoClose" 10000
-                                  "pauseOnHover" true}
-                        :error {"type" "error"
-                                "autoClose" 10000
-                                "pauseOnHover" true}
-                        {})]
-     (.toast js/ReactToastify
-             (r/as-element [:<> [:strong (str title)] [:p (str body)]])
-             (clj->js (merge type-options options))))))

--- a/client/web/src/flybot/client/web/core/db/event.cljs
+++ b/client/web/src/flybot/client/web/core/db/event.cljs
@@ -14,12 +14,17 @@
 (rf/reg-event-fx
  :fx.http/send-post-success
  (fn [_ [_ {:keys [posts]}]]
-   (let [{:post/keys [id] :as post} (:new-post posts)]
+   (let [{:post/keys [id last-edit-date] :as post} (:new-post posts)
+         post-title (web.utils/post->title post)]
      {:fx [[:dispatch [:evt.post/add-post post]]
            [:dispatch [:evt.form/clear :form/fields]]
            [:dispatch [:evt.error/clear-errors]]
            [:dispatch [:evt.post/set-modes :read]]
-           [:fx.log/message ["Post " id " sent."]]]})))
+           [:fx.log/message ["Post " id " sent."]]
+           [:dispatch [:evt.notification/set-notification
+                       :success
+                       (if last-edit-date "Post edited" "New post created")
+                       post-title]]]})))
 
 ;; ---------------- Routing -----------------
 

--- a/client/web/src/flybot/client/web/core/db/event.cljs
+++ b/client/web/src/flybot/client/web/core/db/event.cljs
@@ -146,3 +146,13 @@
  :evt.page/set-current-view
  (fn [db [_ new-match]]
    (assoc db :app/current-view new-match)))
+
+;;; ------ Notifications ------
+
+;; Pop-ups (toasts)
+
+(rf/reg-event-fx
+ :evt.app/toast-notify
+ (fn [{:keys [db]} [_ notification]]
+   (let [theme (-> db :app/theme name)]
+     {:fx [[:fx.app/toast-notify [notification {"theme" theme}]]]})))

--- a/client/web/src/flybot/client/web/core/db/fx.cljs
+++ b/client/web/src/flybot/client/web/core/db/fx.cljs
@@ -1,9 +1,10 @@
 (ns flybot.client.web.core.db.fx
-  (:require [flybot.client.web.core.db.class-utils :as cu]
-            [flybot.client.web.core.db.localstorage :as l-storage]
+  (:require [clojure.edn :as edn]
             [flybot.client.common.db.fx]
-            [clojure.edn :as edn]
-            [re-frame.core :as rf]))
+            [flybot.client.web.core.db.class-utils :as cu]
+            [flybot.client.web.core.db.localstorage :as l-storage]
+            [re-frame.core :as rf]
+            [reagent.core :as reagent]))
 
 ;; ---------- Theme ----------
 
@@ -37,3 +38,28 @@
  :fx.app/set-theme-local-store
  (fn [next-theme]
    (l-storage/set-item :theme next-theme)))
+
+;;; ----- Notifications ------
+
+;; Pop-ups (toasts)
+
+(rf/reg-fx
+ :fx.app/toast-notify
+ (fn [[{:notification/keys [type title body]} options]]
+   (let [type-options (case type
+                        :info {"type" "info"
+                               "autoClose" 10000
+                               "pauseOnHover" true}
+                        :success {"type" "success"
+                                  "autoClose" 5000
+                                  "pauseOnHover" false}
+                        :warning {"type" "warning"
+                                  "autoClose" 10000
+                                  "pauseOnHover" true}
+                        :error {"type" "error"
+                                "autoClose" 10000
+                                "pauseOnHover" true}
+                        {})]
+     (.toast js/ReactToastify
+             (reagent/as-element [:<> [:strong (str title)] [:p (str body)]])
+             (clj->js (merge type-options options))))))

--- a/client/web/test/flybot/client/web/core/dom/page/admin_test.cljs
+++ b/client/web/test/flybot/client/web/core/dom/page/admin_test.cljs
@@ -35,7 +35,8 @@
            admin-alice (update editor-alice :user/roles conj
                                [#:role{:name :admin :date-granted s/alice-date-granted}])
            role-form   (rf/subscribe [:subs/pattern '{:form.role/fields ?x}])
-           errors      (rf/subscribe [:subs/pattern '{:app/errors ?x}])]
+           errors      (rf/subscribe [:subs/pattern '{:app/errors ?x}])
+           notification (rf/subscribe [:subs/pattern {:app/notification '?x}])]
 
        ;;---------- GRANT ROLE ERROR
        (rf/dispatch [:evt.role.form/set-field :admin :user/email "email@wrong.com"])
@@ -49,6 +50,7 @@
        (rf/reg-fx :http-xhrio
                   (fn [_] (rf/dispatch
                            [:fx.http/grant-role-success
+                            :admin
                             {:users {:new-role {:admin admin-alice}}}])))
        ;; fill the new role form
        (rf/dispatch [:evt.role.form/set-field :admin :user/email email])
@@ -56,4 +58,9 @@
        (rf/dispatch [:evt.user.form/grant-role :admin])
        (testing "Form and error cleared."
          (is (not @role-form))
-         (is (not @errors)))))))
+         (is (not @errors)))
+       (testing "Notification sent."
+         (is (= #:notification{:type :success
+                               :title "New role granted"
+                               :body "Alice is now an administrator."}
+                (dissoc @notification :notification/id))))))))


### PR DESCRIPTION
## Closes #234

- [x] Add success notifications for the following actions:
    - [x] Creating a new post
    - [x] Editing a post
    - [x] Removing a post
    - [x] Granting a new role to another user

- [x] Remove pop-up notifications from the mobile app.
    Notifications in the mobile app may eventually be implemented using `toastify-react-native` or another similar package.