### PR TITLE
247 post title mobile fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Regression tests are run on every save and the results are displayed at http://l
 Prerequisites:
 - [prepare your environment](https://reactnative.dev/docs/next/environment-setup)
 - if no `node_modules`, run `npm install` at the root
+- for ios, run `pod install` in the `ios` directory
 - be sure to update `:client-root-path` in config/system.edn
 - only tested with Xcode simulator
 

--- a/client/common/src/flybot/client/common/db/event.cljs
+++ b/client/common/src/flybot/client/common/db/event.cljs
@@ -2,7 +2,7 @@
   (:require [ajax.edn :refer [edn-request-format edn-response-format]]
             [clojure.edn :as edn]
             [day8.re-frame.http-fx]
-            [flybot.client.web.core.utils :as web.utils]
+            [flybot.client.common.utils :as client.utils]
             [flybot.common.utils :as utils :refer [toggle]]
             [flybot.common.validation :as valid]
             [re-frame.core :as rf]))
@@ -63,7 +63,7 @@
  :fx.http/remove-post-success
  (fn [{:keys [db]} [_ {:keys [posts]}]]
    (let [post   (-> posts :removed-post)
-         post-title (web.utils/post->title post)
+         post-title (client.utils/post->title post)
          user-name (-> db :app/user :user/name)]
      {:fx [[:dispatch [:evt.post/delete-post post]]
            [:dispatch [:evt.form/clear :form/fields]]

--- a/client/common/src/flybot/client/common/db/fx.cljs
+++ b/client/common/src/flybot/client/common/db/fx.cljs
@@ -1,13 +1,5 @@
 (ns flybot.client.common.db.fx
-  (:require [cljsjs.react-toastify]
-            [re-frame.core :as rf]
-            [reitit.frontend.easy :as rfe]))
-
-;; ---------- Routing ----------
-
-(rf/reg-fx
- :fx.router/replace-state
- (fn [args] (apply rfe/replace-state args)))
+  (:require [re-frame.core :as rf]))
 
 ;; ---------- Logging ----------
 

--- a/client/common/src/flybot/client/common/utils.cljs
+++ b/client/common/src/flybot/client/common/utils.cljs
@@ -1,5 +1,5 @@
 (ns flybot.client.common.utils
-  "Rendering app notifications as pop-up `toast` notifications in the DOM."
+  "Convenient functions for both web and mobile clients."
   (:require [camel-snake-kebab.core :as csk]
             [camel-snake-kebab.extras :as cske]
             [clojure.string :as str]))

--- a/client/mobile/src/flybot/client/mobile/core/db/event.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/db/event.cljs
@@ -1,8 +1,8 @@
 (ns flybot.client.mobile.core.db.event
   (:require [ajax.edn :refer [edn-request-format edn-response-format]]
             [flybot.client.common.db.event :refer [base-uri]]
+            [flybot.client.common.utils :as client.utils]
             [flybot.client.mobile.core.navigation :as nav]
-            [flybot.client.web.core.utils :as web.utils]
             [flybot.common.utils :refer [temporary-id?]]
             [re-frame.core :as rf]))
 
@@ -12,7 +12,7 @@
  :fx.http/send-post-success
  (fn [_ [_ {:keys [posts]}]]
    (let [{:post/keys [id last-edit-date] :as post} (:new-post posts)
-         post-title (web.utils/post->title post)]
+         post-title (client.utils/post->title post)]
      {:fx [[:dispatch [:evt.post/add-post post]]
            [:dispatch [:evt.form/clear :form/fields]]
            [:dispatch [:evt.error/clear-errors]]

--- a/client/mobile/src/flybot/client/mobile/core/db/fx.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/db/fx.cljs
@@ -1,7 +1,7 @@
 (ns flybot.client.mobile.core.db.fx
   (:require [flybot.client.common.db.fx]
             [flybot.client.mobile.core.db.asyncstorage :as async-storage]
-            [flybot.client.mobile.core.utils :refer [cljs->js]]
+            [flybot.client.common.utils :refer [cljs->js]]
             [re-frame.core :as rf]))
 
 ;; navigation

--- a/client/mobile/src/flybot/client/mobile/core/utils.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/utils.cljs
@@ -1,4 +1,5 @@
 (ns flybot.client.mobile.core.utils
+  "Convenient functions for mobile client."
   (:require [clojure.string :as str]))
 
 (defn format-date

--- a/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
@@ -14,8 +14,6 @@
             [reagent.core :as r]
             [reagent.react-native :as rrn]))
 
-
-
 (def markdown (.-default Markdown))
 (def default-icon (.-default icon))
 (def check-box (.-default BouncyCheckbox))
@@ -77,30 +75,26 @@
                :padding-bottom 5}})
 
 (defn post-author
-  [show-authors? author show-dates? date authored?]
+  [author date authored?]
   [rrn/view
    {:style {:flex-direction "row"
             :align-items "center"}}
-   (when (or show-authors? show-dates?)
-     [:> default-icon
-      {:name "create"
-       :size 30
-       :color (:green colors)}])
-   (when show-authors?
-     [rrn/text
-      {:style {:color (:green colors)
-               :padding 5}}
-      (:user/name author)])
-   (when show-dates?
-     [rrn/text
-      {:style {:color (:green colors)
-               :padding 5}}
-      (utils/format-date date)])
-   (when (or show-authors? show-dates?)
-     [rrn/text
-      {:style {:color (:green colors)
-               :padding 5}}
-      (if authored? "[Authored]" "[Edited]")])])
+   [:> default-icon
+    {:name "create"
+     :size 30
+     :color (:green colors)}]
+   [rrn/text
+    {:style {:color (:green colors)
+             :padding 5}}
+    (:user/name author)]
+   [rrn/text
+    {:style {:color (:green colors)
+             :padding 5}}
+    (utils/format-date date)]
+   [rrn/text
+    {:style {:color (:green colors)
+             :padding 5}}
+    (if authored? "[Authored]" "[Edited]")]])
 
 (defn md-title
   "Returns the title # of the given markdown
@@ -133,9 +127,9 @@
                :border-bottom-width 1
                :border-bottom-color (:blue colors)}
               {:padding 10})}
-    [post-author show-authors? author show-dates? creation-date true]
+    [post-author author creation-date true]
     (when-not (temporary-id? id)
-      [post-author show-authors? last-editor show-dates? last-edit-date false])]
+      [post-author last-editor last-edit-date false])]
    [rrn/view
     {}
     [:> markdown
@@ -197,7 +191,7 @@
                  (rn-alert "Confirmation" "Are you sure you want to save your changes?"
                            [{:text "Cancel"}
                             {:text "Submit"
-                             :on-press #(rf/dispatch [:evt.post.form/send-post post-id])}]))}]
+                             :on-press #(rf/dispatch [:evt.post.form/send-post])}]))}]
    [rrn/button
     {:title "Delete"
      :on-press (fn []

--- a/client/web/src/flybot/client/web/core/db/event.cljs
+++ b/client/web/src/flybot/client/web/core/db/event.cljs
@@ -3,6 +3,7 @@
             [clojure.string :as str]
             [day8.re-frame.http-fx]
             [flybot.client.common.db.event]
+            [flybot.client.common.utils :as client.utils]
             [flybot.client.web.core.utils :as web.utils]
             [flybot.common.utils :as utils :refer [toggle]]
             [re-frame.core :as rf]
@@ -15,7 +16,7 @@
  :fx.http/send-post-success
  (fn [_ [_ {:keys [posts]}]]
    (let [{:post/keys [id last-edit-date] :as post} (:new-post posts)
-         post-title (web.utils/post->title post)]
+         post-title (client.utils/post->title post)]
      {:fx [[:dispatch [:evt.post/add-post post]]
            [:dispatch [:evt.form/clear :form/fields]]
            [:dispatch [:evt.error/clear-errors]]

--- a/client/web/src/flybot/client/web/core/db/fx.cljs
+++ b/client/web/src/flybot/client/web/core/db/fx.cljs
@@ -6,9 +6,14 @@
             [flybot.client.web.core.db.class-utils :as cu]
             [flybot.client.web.core.db.localstorage :as l-storage]
             [re-frame.core :as rf]
+            [reitit.frontend.easy :as rfe]
             [reagent.core :as reagent]))
 
 ;;; -------- Routing ---------
+
+(rf/reg-fx
+ :fx.router/replace-state
+ (fn [args] (apply rfe/replace-state args)))
 
 ;; URL document fragments
 

--- a/client/web/src/flybot/client/web/core/dom/page.cljs
+++ b/client/web/src/flybot/client/web/core/dom/page.cljs
@@ -1,6 +1,7 @@
 (ns flybot.client.web.core.dom.page
   (:require [cljsjs.react-toastify]
             [clojure.string :as str]
+            [flybot.client.common.utils :as client.utils]
             [flybot.client.web.core.dom.page.admin :refer [admin-panel]]
             [flybot.client.web.core.dom.page.options :as page.options]
             [flybot.client.web.core.dom.page.post :as post :refer [blog-post-short page-post]]
@@ -39,7 +40,7 @@
                          (sort-by (case by
                                     :date-created :post/creation-date
                                     :date-updated :post/last-edit-date
-                                    :title web.utils/post->title
+                                    :title client.utils/post->title
                                     :post/creation-date)
                                   (if (= :ascending direction)
                                     compare

--- a/client/web/src/flybot/client/web/core/dom/page/post.cljs
+++ b/client/web/src/flybot/client/web/core/dom/page/post.cljs
@@ -142,7 +142,7 @@
                   (->> other-posts
                        (sort-by :post/default-order)
                        (map-indexed (fn [i post]
-                                      [i (web.utils/post->title post)])))]
+                                      [i (client.utils/post->title post)])))]
               [:option
                {:value position
                 :key (str "position-" position)}

--- a/client/web/src/flybot/client/web/core/dom/page/post.cljs
+++ b/client/web/src/flybot/client/web/core/dom/page/post.cljs
@@ -1,5 +1,6 @@
 (ns flybot.client.web.core.dom.page.post
   (:require [clojure.walk :as walk]
+            [flybot.client.common.utils :as client.utils]
             [flybot.client.web.core.dom.common.link :as link]
             [flybot.client.web.core.dom.common.role :as role]
             [flybot.client.web.core.dom.common.svg :as svg]
@@ -320,7 +321,7 @@
 
 (defn blog-post-short
   [{:post/keys [css-class id] :as post}]
-  (let [post-title (web.utils/post->title post)]
+  (let [post-title (client.utils/post->title post)]
     [:div.post.short
      {:key id
       :id id}

--- a/client/web/src/flybot/client/web/core/dom/profile.cljs
+++ b/client/web/src/flybot/client/web/core/dom/profile.cljs
@@ -1,5 +1,6 @@
 (ns flybot.client.web.core.dom.profile
   (:require [clojure.string :as str]
+            [flybot.client.common.utils :as client.utils]
             [flybot.client.web.core.dom.common.link :as link]
             [flybot.client.web.core.dom.common.svg :as svg]
             [flybot.client.web.core.utils :as web.utils]
@@ -43,7 +44,7 @@
 
 (defn post-short
   [{:post/keys [id page css-class creation-date last-edit-date] :as post}]
-  (let [post-title (web.utils/post->title post)]
+  (let [post-title (client.utils/post->title post)]
     [:div.post.short
      {:key id
       :id id}

--- a/client/web/src/flybot/client/web/core/utils.cljs
+++ b/client/web/src/flybot/client/web/core/utils.cljs
@@ -1,4 +1,5 @@
 (ns flybot.client.web.core.utils
+  "Convenient functions for web client."
   (:require
    [clojure.string :as str]
    [flybot.client.common.utils :refer [post->title]]))

--- a/client/web/src/flybot/client/web/core/utils.cljs
+++ b/client/web/src/flybot/client/web/core/utils.cljs
@@ -1,21 +1,7 @@
 (ns flybot.client.web.core.utils
   (:require
    [clojure.string :as str]
-   [markdown-to-hiccup.core :as mth]))
-
-(defn post->title
-  "Returns a title string based on the given post's Markdown H1 heading. If the
-  content does not contain an H1 heading, returns nil. If the content is not a
-  string, returns nil."
-  [{:post/keys [md-content]}]
-  (when (string? md-content)
-    (some->> md-content
-             mth/md->hiccup
-             (#(mth/hiccup-in % :h1 0))
-             seq
-             flatten
-             (filter string?)
-             str/join)))
+   [flybot.client.common.utils :refer [post->title]]))
 
 (defn title->url-identifier
   "Converts a title string into a URL identifier (slug). Returns nil if the

--- a/common/src/flybot/common/utils.cljc
+++ b/common/src/flybot/common/utils.cljc
@@ -1,4 +1,5 @@
 (ns flybot.common.utils
+  "Convenient functions for both server and client."
   (:require #?(:clj [datalevin.core :as d])))
 
 (defn mk-uuid

--- a/common/src/flybot/common/validation/markdown.cljc
+++ b/common/src/flybot/common/validation/markdown.cljc
@@ -1,4 +1,5 @@
-(ns flybot.common.validation.markdown)
+(ns flybot.common.validation.markdown 
+  (:require [clojure.string :as str]))
 
 ;; Overridden by the figwheel config option :closure-defines
 #?(:cljs (goog-define MOBILE? false)
@@ -12,7 +13,7 @@
   at the start, otherwise returns false."
   [md-content]
   (if MOBILE?
-    true
+    (-> md-content (str/split #"#" 3) second (str/split #"\n") first str/trim seq)
     (let [starts-with-h1? (fn [[div _ [element]]]
                             (and (= :div div) (= :h1 element)))
           contains-exactly-one-h1? (fn [hiccup]

--- a/common/src/flybot/common/validation/markdown.cljc
+++ b/common/src/flybot/common/validation/markdown.cljc
@@ -1,17 +1,25 @@
-(ns flybot.common.validation.markdown
-  (:require [markdown-to-hiccup.core :as mth]))
+(ns flybot.common.validation.markdown)
+
+;; Overridden by the figwheel config option :closure-defines
+#?(:cljs (goog-define MOBILE? false)
+   :clj (def MOBILE? false))
+
+(when-not MOBILE?
+  (require '[markdown-to-hiccup.core :as mth]))
 
 (defn has-valid-h1-title?
   "Returns true if the given Markdown content contains exactly one H1 heading
   at the start, otherwise returns false."
   [md-content]
-  (let [starts-with-h1? (fn [[div _ [element]]]
-                          (and (= :div div) (= :h1 element)))
-        contains-exactly-one-h1? (fn [hiccup]
-                                   (empty? (mth/hiccup-in hiccup :h1 1)))
-        contains-valid-h1? (every-pred starts-with-h1?
-                                       contains-exactly-one-h1?)]
-    (boolean (some-> md-content
-                     mth/md->hiccup
-                     mth/component
-                     contains-valid-h1?))))
+  (if MOBILE?
+    true
+    (let [starts-with-h1? (fn [[div _ [element]]]
+                            (and (= :div div) (= :h1 element)))
+          contains-exactly-one-h1? (fn [hiccup]
+                                     (empty? (mth/hiccup-in hiccup :h1 1)))
+          contains-valid-h1? (every-pred starts-with-h1?
+                                         contains-exactly-one-h1?)]
+      (boolean (some-> md-content
+                       mth/md->hiccup
+                       mth/component
+                       contains-valid-h1?)))))

--- a/ios.cljs.edn
+++ b/ios.cljs.edn
@@ -1,4 +1,6 @@
 ^{:react-native :cli
-  :watch-dirs ["client/mobile/src" "client/common/src"]}
+  :watch-dirs ["client/mobile/src" "client/common/src" "common/src"]}
 {:main flybot.client.mobile.core
- :closure-defines {flybot.client.common.db.event/BASE-URI "http://localhost:9500"}}
+ :closure-defines {flybot.client.common.db.event/BASE-URI "http://localhost:9500"
+                   flybot.common.validation.markdown/MOBILE? true
+                   flybot.client.common.utils/MOBILE? true}}

--- a/server/src/flybot/server/systems/init_data.clj
+++ b/server/src/flybot/server/systems/init_data.clj
@@ -105,7 +105,8 @@
           :md-content (slurp-md "blog" "welcome.md")
           :image-beside #:image{:src "/assets/flybot-logo.png"
                                 :src-dark "/assets/flybot-logo.png"
-                                :alt "Flybot Logo"}}
+                                :alt "Flybot Logo"}
+          :default-order 0}
    #:post{:id (u/mk-uuid)
           :page :blog
           :css-class "md-example"
@@ -116,7 +117,8 @@
           :md-content (slurp-md "blog" "mdsample.md")
           :image-beside #:image{:src "https://octodex.github.com/images/dojocat.jpg"
                                 :src-dark "https://octodex.github.com/images/stormtroopocat.jpg"
-                                :alt "Cat Logo"}}])
+                                :alt "Cat Logo"}
+          :default-order 1}])
 
 (def home-posts
   [#:post{:id (u/mk-uuid)


### PR DESCRIPTION
Closes #247
---

- move `post->title` to `flybot.client.common.utils`
- use goog-define `MOBILE?` flag to only require `markdown-to-hiccup` on the web client