### PR TITLE
243 remove old reframe errors logic

### DIFF
--- a/client/common/src/flybot/client/common/db/event.cljs
+++ b/client/common/src/flybot/client/common/db/event.cljs
@@ -19,17 +19,15 @@
 
 (rf/reg-event-db
  :fx.http/failure
- (fn [db [_ {:keys [status response] :as result}]]
+ (fn [db [_ {:keys [status response]}]]
     ;; result is a map containing details of the failure
    (let [notif-body (if (= "5" (first (str status)))
                       "There was a server error. Please contact support if the issue persists."
                       (str "Status: " status " | " (:message response)))]
-     (-> db
-         (assoc-in [:app/errors :failure-http-result] result)
-         (assoc :app/notification #:notification{:id (utils/mk-uuid)
-                                                 :type :error
-                                                 :title "HTTP error"
-                                                 :body notif-body})))))
+     (assoc db :app/notification #:notification{:id (utils/mk-uuid)
+                                                :type :error
+                                                :title "HTTP error"
+                                                :body notif-body}))))
 
 (rf/reg-event-fx
  :fx.http/all-success
@@ -67,7 +65,6 @@
          user-name (-> db :app/user :user/name)]
      {:fx [[:dispatch [:evt.post/delete-post post]]
            [:dispatch [:evt.form/clear :form/fields]]
-           [:dispatch [:evt.error/clear-errors]]
            [:fx.log/message ["Post " (:post/id post) " deleted by " user-name "."]]
            [:dispatch [:evt.notification/set-notification
                        :success
@@ -85,7 +82,6 @@
  (fn [_ [_ role-granted {:keys [users]}]]
    (let [{:user/keys [name roles]} (-> users :new-role role-granted)]
      {:fx [[:dispatch [:evt.form/clear :form.role/fields]]
-           [:dispatch [:evt.error/clear-errors]]
            [:fx.log/message ["User " name "'s roles are now " (map :role/name roles)]]
            [:dispatch [:evt.notification/set-notification
                        :success
@@ -104,7 +100,6 @@
  (fn [_ [_ role-revoked {:keys [users]}]]
    (let [{:user/keys [name]} (-> users :revoked-role role-revoked)]
      {:fx [[:dispatch [:evt.form/clear :form.role/fields]]
-           [:dispatch [:evt.error/clear-errors]]
            [:fx.log/message
             ["User " name " has had a role revoked: " role-revoked]]
            [:dispatch [:evt.notification/set-notification
@@ -205,8 +200,7 @@
    (let [post (-> db :app/posts (get post-id))]
      (if (= :edit (:post/mode post))
        {:db (assoc-in db [:app/posts post-id :post/mode] :read)
-        :fx [[:dispatch [:evt.form/clear :form/fields]]
-             [:dispatch [:evt.error/clear-errors]]]}
+        :fx [[:dispatch [:evt.form/clear :form/fields]]]}
        {:db (assoc-in db [:app/posts post-id :post/mode] :edit)
         :fx [[:dispatch [:evt.post.form/autofill post-id]]]}))))
 
@@ -327,8 +321,7 @@
                    :format          (edn-request-format {:keywords? true})
                    :response-format (edn-response-format {:keywords? true})
                    :on-success      [:fx.http/post-success]
-                   :on-failure      [:fx.http/failure]}
-      :fx [[:dispatch [:evt.error/clear-errors]]]})))
+                   :on-failure      [:fx.http/failure]}})))
 
 (rf/reg-event-db
  :evt.post.form/set-field
@@ -380,15 +373,8 @@
 (rf/reg-event-db
  :evt.error/set-validation-errors
  (fn [db [_ validation-err]]
-   (-> db
-       (assoc-in [:app/errors :validation-errors] validation-err)
-       (assoc :app/notification #:notification{:id (utils/mk-uuid)
-                                               :type :error
-                                               :sub-type :form
-                                               :title "Form Input Error"
-                                               :body validation-err}))))
-
-(rf/reg-event-db
- :evt.error/clear-errors
- (fn [db _]
-   (dissoc db :app/errors)))
+   (assoc db :app/notification #:notification{:id (utils/mk-uuid)
+                                              :type :error
+                                              :sub-type :form
+                                              :title "Form Input Error"
+                                              :body validation-err})))

--- a/client/common/src/flybot/client/common/db/event.cljs
+++ b/client/common/src/flybot/client/common/db/event.cljs
@@ -378,3 +378,8 @@
                                               :sub-type :form
                                               :title "Form Input Error"
                                               :body validation-err})))
+
+(rf/reg-event-db
+ :evt.notif/clear
+ (fn [db _]
+   (dissoc db :app/notification)))

--- a/client/mobile/src/flybot/client/mobile/core/db/event.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/db/event.cljs
@@ -15,11 +15,10 @@
          post-title (client.utils/post->title post)]
      {:fx [[:dispatch [:evt.post/add-post post]]
            [:dispatch [:evt.form/clear :form/fields]]
-           [:dispatch [:evt.error/clear-errors]]
            [:dispatch [:evt.post/set-modes :read]]
            [:fx.log/message ["Post " id " sent."]]
            [:dispatch [:evt.nav/navigate "posts-list"]]
-           [:dispatch [:evt.notification/set-notification
+           [:dispatch [:evt.notif/set-notif
                        :success
                        (if last-edit-date "Post edited" "New post created")
                        post-title]]]})))
@@ -109,7 +108,6 @@
  (fn [_ [_ post-id]]
    (let [go-back-screen (if (temporary-id? (str post-id)) "posts-list" "post-read")]
      {:fx [[:dispatch [:evt.form/clear :form/fields]]
-           [:dispatch [:evt.error/clear-errors]]
            [:dispatch [:evt.nav/navigate go-back-screen post-id]]]})))
 
 (rf/reg-event-fx

--- a/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
@@ -37,8 +37,8 @@
 ;;---------- errors ----------
 
 (defn notif-message
-  [{:notification/keys [sub-type title body]}]
-  (let [notif-body (if (= :form sub-type)
+  [{:notification/keys [type title body]}]
+  (let [notif-body (if (= :form-error type)
                      (apply str (for [e body]
                                   (str (first e) ": " (apply str (interpose ", " (second e))) "\n")))
                      (str body))]

--- a/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/view/blog.cljs
@@ -36,21 +36,22 @@
 
 ;;---------- errors ----------
 
-(defn errors
+(defn notif-message
+  [{:notification/keys [sub-type title body]}]
+  (let [notif-body (if (= :form sub-type)
+                     (apply str (for [e body]
+                                  (str (first e) ": " (apply str (interpose ", " (second e))) "\n")))
+                     (str body))]
+    (rn-alert (str/upper-case title)
+              notif-body
+              [{:text "Ok"
+                :on-press #(rf/dispatch [:evt.notif/clear])}])))
+
+(defn notif
   []
-  [rrn/view
-   {:style {:background-color "white"
-            :color "red"
-            :justify-content "center"
-            :align-items "center"}}
-   (when-let [http-error @(rf/subscribe [:subs/pattern '{:app/errors {:failure-http-result ?x}}])]
-     [rrn/text
-      {:style {:color "red"}}
-      (str "server error:" (-> http-error :response :message))])
-   (when-let [validation-error @(rf/subscribe [:subs/pattern '{:app/errors {:validation-errors ?x}}])]
-     [rrn/text
-      {:style {:color "red"}}
-      (str "validation error: " validation-error)])])
+  (let [notification @(rf/subscribe [:subs/pattern {:app/notification '?x}])]
+    (when notification
+      (notif-message notification))))
 
 ;;---------- Read Post Screen -----------
 
@@ -245,7 +246,7 @@
   [post-id]
   [rrn/view
    [edit-post-btns post-id]
-   [errors]
+   [notif]
    [edit-post-form]])
 
 (defn preview-post-btn

--- a/client/web/src/flybot/client/web/core/db/event.cljs
+++ b/client/web/src/flybot/client/web/core/db/event.cljs
@@ -19,7 +19,6 @@
          post-title (client.utils/post->title post)]
      {:fx [[:dispatch [:evt.post/add-post post]]
            [:dispatch [:evt.form/clear :form/fields]]
-           [:dispatch [:evt.error/clear-errors]]
            [:dispatch [:evt.post/set-modes :read]]
            [:fx.log/message ["Post " id " sent."]]
            [:dispatch [:evt.notification/set-notification

--- a/client/web/src/flybot/client/web/core/db/event.cljs
+++ b/client/web/src/flybot/client/web/core/db/event.cljs
@@ -21,7 +21,7 @@
            [:dispatch [:evt.form/clear :form/fields]]
            [:dispatch [:evt.post/set-modes :read]]
            [:fx.log/message ["Post " id " sent."]]
-           [:dispatch [:evt.notification/set-notification
+           [:dispatch [:evt.notif/set-notif
                        :success
                        (if last-edit-date "Post edited" "New post created")
                        post-title]]]})))

--- a/client/web/src/flybot/client/web/core/db/fx.cljs
+++ b/client/web/src/flybot/client/web/core/db/fx.cljs
@@ -60,8 +60,8 @@
 ;; ----- Notification ------
 
 (defn toast-message
-  [{:notification/keys [sub-type title body]}]
-  (if (= :form sub-type)
+  [{:notification/keys [type title body]}]
+  (if (= :form-error type)
     [:<> [:strong (str/upper-case title)]
      [:ul
       (doall
@@ -77,10 +77,11 @@
  :fx.app/toast-notify
  (fn [[{:notification/keys [type] :as notif} options]]
    (let [type-options (case type
-                        :info    {:type "info" :auto-close 10000 :pause-on-hover true}
-                        :success {:type "success" :auto-close 5000 :pause-on-hover false}
-                        :warning {:type "warning" :auto-close 10000 :pause-on-hover true}
-                        :error   {:type "error" :auto-close 10000 :pause-on-hover true}
+                        :info       {:type "info" :auto-close 10000 :pause-on-hover true}
+                        :success    {:type "success" :auto-close 5000 :pause-on-hover false}
+                        :warning    {:type "warning" :auto-close 10000 :pause-on-hover true}
+                        :form-error {:type "error" :auto-close 10000 :pause-on-hover true}
+                        :http-error {:type "error" :auto-close 10000 :pause-on-hover true}
                         {})]
      (.toast js/ReactToastify
              (reagent/as-element (toast-message notif))

--- a/client/web/test/flybot/client/web/core/db_test.cljs
+++ b/client/web/test/flybot/client/web/core/db_test.cljs
@@ -41,7 +41,6 @@
          user         (rf/subscribe [:subs/pattern '{:app/user ?x}])
          navbar-open? (rf/subscribe [:subs/pattern '{:nav/navbar-open? ?x}])
          posts        (rf/subscribe [:subs.post/posts :home])
-         http-error   (rf/subscribe [:subs/pattern '{:app/errors {:failure-http-result ?x}}])
          notification (rf/subscribe [:subs/pattern {:app/notification '?x}])]
      ;;---------- SERVER ERROR
      ;; Mock failure http request
@@ -51,7 +50,6 @@
      ;; Initialize db
      (rf/dispatch [:evt.app/initialize])
      (testing "Initital db state is accurate in case of server error."
-       (is (= {:status 500} @http-error))
        (is (= #:notification{:type :error
                              :body "There was a server error. Please contact support if the issue persists."}
               (select-keys @notification [:notification/type
@@ -128,8 +126,6 @@
            p1-form          (rf/subscribe [:subs/pattern '{:form/fields ?x}])
            p1-preview       (rf/subscribe [:subs/pattern '{:form/fields {:post/view ?x}}])
            posts            (rf/subscribe [:subs.post/posts :home])
-           errors           (rf/subscribe [:subs/pattern '{:app/errors ?x}])
-           validation-error (rf/subscribe [:subs/pattern '{:app/errors {:validation-errors ?x}}])
            notification     (rf/subscribe [:subs/pattern {:app/notification '?x}])
            new-post-1       (assoc s/post-1
                                    :post/md-content     "#New Content 1"
@@ -161,8 +157,7 @@
        (rf/dispatch [:evt.post.form/set-field :post/md-content nil])
      ;; Send post but validation error
        (rf/dispatch [:evt.post.form/send-post])
-       (testing "Validation error added to db."
-         (is @validation-error)
+       (testing "Validation error notification added to db."
          (is (= #:notification{:type :error
                                :title "Form Input Error"}
                 (select-keys @notification [:notification/type
@@ -182,9 +177,8 @@
          (is (= [(assoc new-post-1 :post/mode :read)
                  (assoc s/post-2 :post/mode :read)]
                 @posts)))
-       (testing "Form and errors cleared."
-         (is (not @p1-form))
-         (is (not @errors)))
+       (testing "Form cleared."
+         (is (not @p1-form)))
        (testing "Notification sent."
          (is (= #:notification{:type :success
                                :title "Post edited"

--- a/client/web/test/flybot/client/web/core/db_test.cljs
+++ b/client/web/test/flybot/client/web/core/db_test.cljs
@@ -50,7 +50,7 @@
      ;; Initialize db
      (rf/dispatch [:evt.app/initialize])
      (testing "Initital db state is accurate in case of server error."
-       (is (= #:notification{:type :error
+       (is (= #:notification{:type :http-error
                              :body "There was a server error. Please contact support if the issue persists."}
               (select-keys @notification [:notification/type
                                           :notification/body]))))
@@ -158,7 +158,7 @@
      ;; Send post but validation error
        (rf/dispatch [:evt.post.form/send-post])
        (testing "Validation error notification added to db."
-         (is (= #:notification{:type :error
+         (is (= #:notification{:type :form-error
                                :title "Form Input Error"}
                 (select-keys @notification [:notification/type
                                             :notification/title]))))

--- a/client/web/test/flybot/client/web/core/dom/page/admin_test.cljs
+++ b/client/web/test/flybot/client/web/core/dom/page/admin_test.cljs
@@ -46,8 +46,7 @@
            (is @role-form)
            (is (= "Form Input Error" (:notification/title @notification))))
          (rf/dispatch [:evt.form/clear :form.role/fields])
-         (rf/dispatch [:evt.error/clear-errors])
-         (rf/dispatch [:evt.notification/set-notification nil]))
+         (rf/dispatch [:evt.notif/clear]))
 
        (testing "Revoke role: Validation error:"
          (rf/dispatch [:evt.role.form/set-field :revoked-role :admin :user/email "email@wrong.com"])
@@ -56,8 +55,7 @@
            (is @role-form)
            (is (= "Form Input Error" (:notification/title @notification))))
          (rf/dispatch [:evt.form/clear :form.role/fields])
-         (rf/dispatch [:evt.error/clear-errors])
-         (rf/dispatch [:evt.notification/set-notification nil]))
+         (rf/dispatch [:evt.notif/clear]))
 
        (testing "Revoke role: Role not present:"
          (rf/reg-fx :http-xhrio

--- a/client/web/test/flybot/client/web/core/dom/page/admin_test.cljs
+++ b/client/web/test/flybot/client/web/core/dom/page/admin_test.cljs
@@ -35,7 +35,6 @@
            admin-alice (update editor-alice :user/roles conj
                                [#:role{:name :admin :date-granted s/alice-date-granted}])
            role-form   (rf/subscribe [:subs/pattern '{:form.role/fields ?x}])
-           errors      (rf/subscribe [:subs/pattern '{:app/errors ?x}])
            notification (rf/subscribe [:subs/pattern {:app/notification '?x}])]
 
        (testing "Grant role: Validation error:"
@@ -43,9 +42,8 @@
          (rf/dispatch [:evt.role.form/set-field :new-role :admin :user/email "email@wrong.com"])
          ;; Attempt to grant role
          (rf/dispatch [:evt.user.form/grant-role :admin])
-         (testing "Form not cleared, error and notification added to DB."
+         (testing "Form not cleared, error notification added to DB."
            (is @role-form)
-           (is @errors)
            (is (= "Form Input Error" (:notification/title @notification))))
          (rf/dispatch [:evt.form/clear :form.role/fields])
          (rf/dispatch [:evt.error/clear-errors])
@@ -54,9 +52,8 @@
        (testing "Revoke role: Validation error:"
          (rf/dispatch [:evt.role.form/set-field :revoked-role :admin :user/email "email@wrong.com"])
          (rf/dispatch [:evt.user.form/revoke-role :admin])
-         (testing "Form not cleared, error and notification added to DB."
+         (testing "Form not cleared, error notification added to DB."
            (is @role-form)
-           (is @errors)
            (is (= "Form Input Error" (:notification/title @notification))))
          (rf/dispatch [:evt.form/clear :form.role/fields])
          (rf/dispatch [:evt.error/clear-errors])
@@ -69,9 +66,8 @@
          (rf/dispatch [:evt.role.form/set-field
                        :revoked-role :admin :user/email email])
          (rf/dispatch [:evt.user.form/revoke-role :admin])
-         (testing "Form not cleared, error and notification added to DB."
+         (testing "Form not cleared, error notification added to DB."
            (is @role-form)
-           (is @errors)
            (is (= "HTTP error" (:notification/title @notification)))))
 
        (testing "Grant role: Success:"
@@ -83,9 +79,8 @@
          (rf/dispatch [:evt.role.form/set-field
                        :new-role :admin :user/email email])
          (rf/dispatch [:evt.user.form/grant-role :admin])
-         (testing "Form and error cleared."
-           (is (not @role-form))
-           (is (not @errors)))
+         (testing "Form cleared."
+           (is (not @role-form)))
          (testing "Notification sent."
            (is (= #:notification{:type :success
                                  :title "New role granted"
@@ -101,9 +96,8 @@
          (rf/dispatch [:evt.role.form/set-field
                        :revoked-role :admin :user/email email])
          (rf/dispatch [:evt.user.form/revoke-role :admin])
-         (testing "Form and error cleared."
-           (is (not @role-form))
-           (is (not @errors)))
+         (testing "Form cleared."
+           (is (not @role-form)))
          (testing "Notification sent."
            (is (= #:notification{:type :success
                                  :title "Role revoked"


### PR DESCRIPTION
Closes #243
---

- Remove old error logic in both web and mobile clients
- Use notification in mobile within an alert for the errors
- Use the re-frame event `evt.notif/set-notif` for all notifs including validation errors (get rid of `:evt.error/set-validation-errors`)