### PR TITLE
Add titles for different web pages

### DIFF
--- a/client/web/src/flybot/client/web/core/db/event.cljs
+++ b/client/web/src/flybot/client/web/core/db/event.cljs
@@ -144,6 +144,11 @@
 ;; ---------- View ----------
 
 (rf/reg-event-fx
+ :evt.page/set-title
+ (fn [_ [_ page-title]]
+   {:fx [[:fx.app/set-html-title page-title]]}))
+
+(rf/reg-event-fx
  :evt.page/set-current-view
  (fn [{:keys [db]} [_ new-match]]
    {:db (assoc db :app/current-view new-match)

--- a/client/web/src/flybot/client/web/core/db/fx.cljs
+++ b/client/web/src/flybot/client/web/core/db/fx.cljs
@@ -6,8 +6,8 @@
             [flybot.client.web.core.db.class-utils :as cu]
             [flybot.client.web.core.db.localstorage :as l-storage]
             [re-frame.core :as rf]
-            [reitit.frontend.easy :as rfe]
-            [reagent.core :as reagent]))
+            [reagent.core :as reagent]
+            [reitit.frontend.easy :as rfe]))
 
 ;;; -------- Routing ---------
 
@@ -23,6 +23,13 @@
    (reagent/after-render #(let [el (or (.getElementById js/document fragment)
                                        (.getElementById js/document "app"))]
                             (.scrollIntoView el)))))
+
+;;; ------- Page title -------
+
+(rf/reg-fx
+ :fx.app/set-html-title
+ (fn [title]
+   (set! (.-title js/document) title)))
 
 ;; ---------- Theme ----------
 
@@ -59,6 +66,8 @@
 
 ;; ----- Notification ------
 
+;; Pop-ups (toasts)
+
 (defn toast-message
   [{:notification/keys [sub-type title body]}]
   (if (= :form sub-type)
@@ -70,8 +79,6 @@
           [:strong (first e)] 
           (str ": " (apply str (interpose ", " (second e))))]))]]
     [:<> [:strong (str/upper-case title)] [:p (str body)]]))
-
-;; Pop-ups (toasts)
 
 (rf/reg-fx
  :fx.app/toast-notify

--- a/client/web/src/flybot/client/web/core/dom/header.cljs
+++ b/client/web/src/flybot/client/web/core/dom/header.cljs
@@ -14,8 +14,8 @@
 
 (defn navbar-content []
   [(internal-link :flybot/home "Home")
+   (internal-link :flybot/about "About")
    (internal-link :flybot/apply "Apply")
-   (internal-link :flybot/about "About Us")
    (internal-link :flybot/blog "Blog")
    (internal-link :flybot/contact "Contact" false)
    (login-link)])

--- a/client/web/src/flybot/client/web/core/dom/page.cljs
+++ b/client/web/src/flybot/client/web/core/dom/page.cljs
@@ -48,6 +48,12 @@
                                   posts))
                        (sort-by :post/default-order posts))
         new-post {:post/id "new-post-temp-id"}]
+    (set! (.-title js/document) (case page-name
+                                  :home "Flybot"
+                                  :about "About | Flybot"
+                                  :apply "Apply | Flybot"
+                                  :blog "Blog | Flybot"
+                                  "Flybot"))
     [:section.container
      {:class (name page-name)
       :key   (name page-name)}
@@ -79,16 +85,21 @@
                          vals
                          first
                          post/add-post-hiccup-content)]
+    (set! (.-title js/document) (str (client.utils/post->title queried-post)
+                                     " - Blog | Flybot"))
     [:section.container
      {:class (name :blog)
       :key   (name :blog)}
      (if queried-post
        (page-post queried-post)
-       [:div.post
-        [:h2 "No blog posts reside here (yet…)"]
-        [:p "Check your URL while we work on filling up the space here! 🚧 👷 🚧"]])]))
+       (do
+         (set! (.-title js/document) "Post not found - Blog | Flybot")
+         [:div.post
+          [:h2 "No blog posts reside here (yet…)"]
+          [:p "Check your URL while we work on filling up the space here! 🚧 👷 🚧"]]))]))
 
 (defn admin-page
   "Returns the admin content."
   []
+  (set! (.-title js/document) "Administrator settings | Flybot")
   [admin-panel])

--- a/client/web/src/flybot/client/web/core/dom/page.cljs
+++ b/client/web/src/flybot/client/web/core/dom/page.cljs
@@ -5,6 +5,7 @@
             [flybot.client.web.core.dom.page.admin :refer [admin-panel]]
             [flybot.client.web.core.dom.page.options :as page.options]
             [flybot.client.web.core.dom.page.post :as post :refer [blog-post-short page-post]]
+            [flybot.client.web.core.dom.page.title :as title]
             [flybot.client.web.core.utils :as web.utils]
             [re-frame.core :as rf]))
 
@@ -48,24 +49,25 @@
                                   posts))
                        (sort-by :post/default-order posts))
         new-post {:post/id "new-post-temp-id"}]
-    (set! (.-title js/document) (case page-name
-                                  :home "Flybot"
-                                  :about "About | Flybot"
-                                  :apply "Apply | Flybot"
-                                  :blog "Blog | Flybot"
-                                  "Flybot"))
-    [:section.container
-     {:class (name page-name)
-      :key   (name page-name)}
-     [:h1 page-name]
-     (when (= :blog page-name)
-       [:div.post [page.options/blog-sorting-form]])
-     [page-post new-post :demote-headings]
-     (doall
-      (for [post sorted-posts]
-        (if (= :blog page-name)
-          (blog-post-short post)
-          (page-post post :demote-headings))))]))
+    [:<>
+     [title/page-title (case page-name
+                         :home "Flybot"
+                         :about "About | Flybot"
+                         :apply "Apply | Flybot"
+                         :blog "Blog | Flybot"
+                         "Flybot")]
+     [:section.container
+      {:class (name page-name)
+       :key   (name page-name)}
+      [:h1 page-name]
+      (when (= :blog page-name)
+        [:div.post [page.options/blog-sorting-form]])
+      [page-post new-post :demote-headings]
+      (doall
+       (for [post sorted-posts]
+         (if (= :blog page-name)
+           (blog-post-short post)
+           (page-post post :demote-headings))))]]))
 
 (defn blog-single-post-page
   "Given the blog post identifier, returns the corresponding post in a page.
@@ -85,21 +87,23 @@
                          vals
                          first
                          post/add-post-hiccup-content)]
-    (set! (.-title js/document) (str (client.utils/post->title queried-post)
-                                     " - Blog | Flybot"))
-    [:section.container
-     {:class (name :blog)
-      :key   (name :blog)}
-     (if queried-post
-       (page-post queried-post)
-       (do
-         (set! (.-title js/document) "Post not found - Blog | Flybot")
+    [:<>
+     [title/page-title (str (client.utils/post->title queried-post)
+                            " - Blog | Flybot")]
+     [:section.container
+      {:class (name :blog)
+       :key   (name :blog)}
+      (if queried-post
+        (page-post queried-post)
+        [:<>
+         [title/page-title "Post not found - Blog | Flybot"]
          [:div.post
           [:h2 "No blog posts reside here (yet…)"]
-          [:p "Check your URL while we work on filling up the space here! 🚧 👷 🚧"]]))]))
+          [:p "Check your URL while we work on filling up the space here! 🚧 👷 🚧"]]])]]))
 
 (defn admin-page
   "Returns the admin content."
   []
-  (set! (.-title js/document) "Administrator settings | Flybot")
-  [admin-panel])
+  [:<>
+   [title/page-title "Administrator settings | Flybot"]
+   [admin-panel]])

--- a/client/web/src/flybot/client/web/core/dom/page/title.cljs
+++ b/client/web/src/flybot/client/web/core/dom/page/title.cljs
@@ -1,0 +1,11 @@
+(ns flybot.client.web.core.dom.page.title
+  (:require [re-frame.core :as rf]))
+
+(defn page-title
+  [title-text]
+  (let [{notification-type :notification/type
+         notification-title :notification/title}
+        @(rf/subscribe [:subs/pattern {:app/notification '?x}])]
+    (rf/dispatch [:evt.page/set-title (str (when (= :error notification-type)
+                                             (str notification-title " - "))
+                                           title-text)])))

--- a/client/web/src/flybot/client/web/core/dom/page/title.cljs
+++ b/client/web/src/flybot/client/web/core/dom/page/title.cljs
@@ -5,7 +5,9 @@
   [title-text]
   (let [{notification-type :notification/type
          notification-title :notification/title}
-        @(rf/subscribe [:subs/pattern {:app/notification '?x}])]
-    (rf/dispatch [:evt.page/set-title (str (when (= :error notification-type)
-                                             (str notification-title " - "))
-                                           title-text)])))
+        @(rf/subscribe [:subs/pattern {:app/notification '?x}])
+        title-error-text (when (some-> notification-type
+                                       namespace
+                                       (= "error"))
+                           (str notification-title " - "))]
+    (rf/dispatch [:evt.page/set-title (str title-error-text title-text)])))

--- a/client/web/src/flybot/client/web/core/dom/profile.cljs
+++ b/client/web/src/flybot/client/web/core/dom/profile.cljs
@@ -3,6 +3,7 @@
             [flybot.client.common.utils :as client.utils]
             [flybot.client.web.core.dom.common.link :as link]
             [flybot.client.web.core.dom.common.svg :as svg]
+            [flybot.client.web.core.dom.page.title :as title]
             [flybot.client.web.core.utils :as web.utils]
             [re-frame.core :as rf]))
 
@@ -65,9 +66,9 @@
          posts-edited   (->> all-posts
                              (filter :post/last-editor)
                              (filter #(= id (-> % :post/last-editor :user/id))))]
-     (set! (.-title js/document) (str user-name "'s profile | Flybot"))
      (if email
        [:<>
+        [title/page-title (str (or user-name email) "'s profile | Flybot")]
         [:h1 "User Profile: " user-name]
         [:div.perso-details
          [:div
@@ -87,6 +88,8 @@
          (doall
           (for [post posts-created]
             (post-short post)))]]
-       [:div
-        [:h2 "You are not logged in."]
-        [:p "This section is only accessible to logged-in users."]]))])
+       [:<>
+        [title/page-title "User profile | Flybot"]
+        [:div
+         [:h2 "You are not logged in."]
+         [:p "This section is only accessible to logged-in users."]]]))])

--- a/client/web/src/flybot/client/web/core/dom/profile.cljs
+++ b/client/web/src/flybot/client/web/core/dom/profile.cljs
@@ -65,6 +65,7 @@
          posts-edited   (->> all-posts
                              (filter :post/last-editor)
                              (filter #(= id (-> % :post/last-editor :user/id))))]
+     (set! (.-title js/document) (str user-name "'s profile | Flybot"))
      (if email
        [:<>
         [:h1 "User Profile: " user-name]
@@ -88,4 +89,4 @@
             (post-short post)))]]
        [:div
         [:h2 "You are not logged in."]
-        [:p "This section is dedicated to logged-in users."]]))])
+        [:p "This section is only accessible to logged-in users."]]))])


### PR DESCRIPTION
## Closes #249

- [x] Set different page titles (e.g., `Flybot`, `About | Flybot`, `Blog | Flybot`).
    The page title format mirrors that of [MDN Web Docs](https://developer.mozilla.org/en-US/).
    - [x] Blog post page titles follow the format `Blog post title - Blog | Flybot` (also similar to MDN Web Docs).
    - [x] The title for the user profile page follows the format `User Name's profile | Flybot`.

- [x] Dynamically update page titles on encountering errors.[^error-in-title]
    For example, if the website encounters an HTTP error when the user tries to change settings on the administrator settings page, then the page title reads `HTTP error - Administrator settings | Flybot`.

[^error-in-title]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title#accessibility_concerns