### PR TITLE
Only manually set cookie for mobile app

### DIFF
--- a/client/mobile/src/flybot/client/mobile/core/db/event.cljs
+++ b/client/mobile/src/flybot/client/mobile/core/db/event.cljs
@@ -1,6 +1,5 @@
 (ns flybot.client.mobile.core.db.event
-  (:require [ajax.edn :refer [edn-request-format edn-response-format]]
-            [flybot.client.common.db.event :refer [base-uri]]
+  (:require [flybot.client.common.db.event :refer [http-xhrio-default]]
             [flybot.client.common.utils :as client.utils]
             [flybot.client.mobile.core.navigation :as nav]
             [flybot.common.utils :refer [temporary-id?]]
@@ -31,38 +30,35 @@
    {:db         (assoc
                  db
                  :navigator/ref @nav/nav-ref)
-    :http-xhrio {:method          :post
-                 :uri             (base-uri "/pattern")
-                 :headers {:cookie (:user/cookie db)}
-                 :params {:posts
-                          {(list :all :with [])
-                           [{:post/id '?
-                             :post/page '?
-                             :post/css-class '?
-                             :post/creation-date '?
-                             :post/last-edit-date '?
-                             :post/author {:user/id '?
-                                           :user/name '?}
-                             :post/last-editor {:user/id '?
-                                                :user/name '?}
-                             :post/md-content '?
-                             :post/image-beside {:image/src '?
-                                                 :image/src-dark '?
-                                                 :image/alt '?}
-                             :post/default-order '?}]}
-                          :users
-                          {:auth
-                           {(list :logged :with [])
-                            {:user/id '?
-                             :user/email '?
-                             :user/name '?
-                             :user/picture '?
-                             :user/roles [{:role/name '?
-                                           :role/date-granted '?}]}}}}
-                 :format          (edn-request-format {:keywords? true})
-                 :response-format (edn-response-format {:keywords? true})
-                 :on-success      [:fx.http/all-success]
-                 :on-failure      [:fx.http/failure]}}))
+    :http-xhrio (merge http-xhrio-default
+                       {:headers    {:cookie (:user/cookie db)}
+                        :params     {:posts
+                                     {(list :all :with [])
+                                      [{:post/id '?
+                                        :post/page '?
+                                        :post/css-class '?
+                                        :post/creation-date '?
+                                        :post/last-edit-date '?
+                                        :post/author {:user/id '?
+                                                      :user/name '?}
+                                        :post/last-editor {:user/id '?
+                                                           :user/name '?}
+                                        :post/md-content '?
+                                        :post/image-beside {:image/src '?
+                                                            :image/src-dark '?
+                                                            :image/alt '?}
+                                        :post/default-order '?}]}
+                                     :users
+                                     {:auth
+                                      {(list :logged :with [])
+                                       {:user/id '?
+                                        :user/email '?
+                                        :user/name '?
+                                        :user/picture '?
+                                        :user/roles [{:role/name '?
+                                                      :role/date-granted '?}]}}}}
+                        
+                        :on-success [:fx.http/all-success]})}))
 
 (rf/reg-event-fx
  :evt.app/initialize-with-cookie

--- a/client/web/src/flybot/client/web/core/db/event.cljs
+++ b/client/web/src/flybot/client/web/core/db/event.cljs
@@ -1,8 +1,7 @@
 (ns flybot.client.web.core.db.event
-  (:require [ajax.edn :refer [edn-request-format edn-response-format]]
-            [clojure.string :as str]
+  (:require [clojure.string :as str]
             [day8.re-frame.http-fx]
-            [flybot.client.common.db.event]
+            [flybot.client.common.db.event :refer [http-xhrio-default]]
             [flybot.client.common.utils :as client.utils]
             [flybot.client.web.core.utils :as web.utils]
             [flybot.common.utils :as utils :refer [toggle]]
@@ -84,37 +83,33 @@
                    :app/theme        app-theme
                    :user/mode        :reader
                    :nav/navbar-open? false)
-      :http-xhrio {:method          :post
-                   :uri             "/pattern"
-                   :params {:posts
-                            {(list :all :with [])
-                             [{:post/id '?
-                               :post/page '?
-                               :post/css-class '?
-                               :post/creation-date '?
-                               :post/last-edit-date '?
-                               :post/author {:user/id '?
-                                             :user/name '?}
-                               :post/last-editor {:user/id '?
-                                                  :user/name '?}
-                               :post/md-content '?
-                               :post/image-beside {:image/src '?
-                                                   :image/src-dark '?
-                                                   :image/alt '?}
-                               :post/default-order '?}]}
-                            :users
-                            {:auth
-                             {(list :logged :with [])
-                              {:user/id '?
-                               :user/email '?
-                               :user/name '?
-                               :user/picture '?
-                               :user/roles [{:role/name '?
-                                             :role/date-granted '?}]}}}}
-                   :format          (edn-request-format {:keywords? true})
-                   :response-format (edn-response-format {:keywords? true})
-                   :on-success      [:fx.http/all-success]
-                   :on-failure      [:fx.http/failure]}
+      :http-xhrio (merge http-xhrio-default
+                         {:params     {:posts
+                                       {(list :all :with [])
+                                        [{:post/id '?
+                                          :post/page '?
+                                          :post/css-class '?
+                                          :post/creation-date '?
+                                          :post/last-edit-date '?
+                                          :post/author {:user/id '?
+                                                        :user/name '?}
+                                          :post/last-editor {:user/id '?
+                                                             :user/name '?}
+                                          :post/md-content '?
+                                          :post/image-beside {:image/src '?
+                                                              :image/src-dark '?
+                                                              :image/alt '?}
+                                          :post/default-order '?}]}
+                                       :users
+                                       {:auth
+                                        {(list :logged :with [])
+                                         {:user/id '?
+                                          :user/email '?
+                                          :user/name '?
+                                          :user/picture '?
+                                          :user/roles [{:role/name '?
+                                                        :role/date-granted '?}]}}}}
+                          :on-success [:fx.http/all-success]})
       :fx         [[:fx.app/update-html-class app-theme]]})))
 
 ;; Theme (dark/light)

--- a/ios.cljs.edn
+++ b/ios.cljs.edn
@@ -2,5 +2,6 @@
   :watch-dirs ["client/mobile/src" "client/common/src" "common/src"]}
 {:main flybot.client.mobile.core
  :closure-defines {flybot.client.common.db.event/BASE-URI "http://localhost:9500"
+                   flybot.client.common.db.event/MOBILE? true
                    flybot.common.validation.markdown/MOBILE? true
                    flybot.client.common.utils/MOBILE? true}}


### PR DESCRIPTION
Closes #252

- only manually set cookies for the mobile app
- introduce `http-xhrio-default` to refactor `http-xhrio` fx