### PR TITLE
Add syntax highlighting for Markdown code blocks

### DIFF
--- a/client/web/src/flybot/client/web/core/db/event.cljs
+++ b/client/web/src/flybot/client/web/core/db/event.cljs
@@ -128,6 +128,13 @@
       :fx [[:fx.app/set-theme-local-store next-theme]
            [:fx.app/toggle-css-class [cur-theme next-theme]]]})))
 
+;; Code syntax highlighting
+
+(rf/reg-event-fx
+ :evt.app/highlight-code
+ (fn [_ _]
+   {:fx [[:fx.app/highlight-code nil]]}))
+
 ;; ---------- Navbar ----------
 
 (rf/reg-event-db

--- a/client/web/src/flybot/client/web/core/db/event.cljs
+++ b/client/web/src/flybot/client/web/core/db/event.cljs
@@ -132,8 +132,8 @@
 
 (rf/reg-event-fx
  :evt.app/highlight-code
- (fn [_ _]
-   {:fx [[:fx.app/highlight-code nil]]}))
+ (fn [_ [_ html-id]]
+   {:fx [[:fx.app/highlight-code html-id]]}))
 
 ;; ---------- Navbar ----------
 

--- a/client/web/src/flybot/client/web/core/db/fx.cljs
+++ b/client/web/src/flybot/client/web/core/db/fx.cljs
@@ -70,7 +70,8 @@
 
 (rf/reg-fx
  :fx.app/highlight-code
- (fn [_]
+ (fn [id]
+   (.configure js/hljs #js {:cssSelector (str "#" id " pre code")})
    (.highlightAll js/hljs)))
 
 ;; ----- Notification ------

--- a/client/web/src/flybot/client/web/core/db/fx.cljs
+++ b/client/web/src/flybot/client/web/core/db/fx.cljs
@@ -5,6 +5,7 @@
             [flybot.client.common.db.fx]
             [flybot.client.common.utils :refer [cljs->js]]
             [flybot.client.web.core.db.class-utils :as cu]
+            [flybot.client.web.core.db.fx.highlight]
             [flybot.client.web.core.db.localstorage :as l-storage]
             [re-frame.core :as rf]
             [reagent.core :as reagent]

--- a/client/web/src/flybot/client/web/core/db/fx.cljs
+++ b/client/web/src/flybot/client/web/core/db/fx.cljs
@@ -1,5 +1,6 @@
 (ns flybot.client.web.core.db.fx
-  (:require [clojure.edn :as edn]
+  (:require [cljsjs.highlight]
+            [clojure.edn :as edn]
             [clojure.string :as str]
             [flybot.client.common.db.fx]
             [flybot.client.common.utils :refer [cljs->js]]
@@ -63,6 +64,13 @@
  :fx.app/set-theme-local-store
  (fn [next-theme]
    (l-storage/set-item :theme next-theme)))
+
+;; code syntax highlighting
+
+(rf/reg-fx
+ :fx.app/highlight-code
+ (fn [_]
+   (.highlightAll js/hljs)))
 
 ;; ----- Notification ------
 

--- a/client/web/src/flybot/client/web/core/db/fx/highlight.cljs
+++ b/client/web/src/flybot/client/web/core/db/fx/highlight.cljs
@@ -1,0 +1,12 @@
+(ns flybot.client.web.core.db.fx.highlight
+  (:require [cljsjs.highlight.langs.asciidoc]
+            [cljsjs.highlight.langs.bash]
+            [cljsjs.highlight.langs.clojure]
+            [cljsjs.highlight.langs.clojure-repl]
+            [cljsjs.highlight.langs.cpp]
+            [cljsjs.highlight.langs.dockerfile]
+            [cljsjs.highlight.langs.java]
+            [cljsjs.highlight.langs.javascript]
+            [cljsjs.highlight.langs.lisp]
+            [cljsjs.highlight.langs.markdown]
+            [cljsjs.highlight.langs.python]))

--- a/client/web/src/flybot/client/web/core/dom/hiccup.cljs
+++ b/client/web/src/flybot/client/web/core/dom/hiccup.cljs
@@ -3,24 +3,49 @@
             [markdown-to-hiccup.core :as mth]
             [re-frame.core :as rf]))
 
+(defn- hiccup-with-properties
+  "Add an empty property map to Hiccup vectors without one."
+  [[tag & rest :as hiccup]]
+  (if (map? (first rest))
+    hiccup
+    (into [tag {}] rest)))
+
 ;; ---------- Post hiccup conversion logic ----------
 
 (defn md-dark-image
-  "Extract the dark mode src from the markdown
-   and add it to the hiccup props."
+  "Extracts the dark mode src from the markdown
+  and add it to the hiccup props."
   [[tag {:keys [srcdark] :as props} value]] 
   (if (and srcdark (= :dark @(rf/subscribe [:subs/pattern '{:app/theme ?x}])))
     [tag (assoc props :src (:srcdark props)) value]
     [tag props value]))
 
+(defn md-code-block-default-plaintext
+  "Marks code blocks without any specified languages as plain text."
+  [h]
+  (let [[_ props content] (hiccup-with-properties h)]
+    (if (= :code (get content 0))
+      (let [[_ code-props code-content] (hiccup-with-properties content)]
+        [:pre props
+         [:code (merge {:class "text"} code-props)
+          code-content]])
+      h)))
+
 (defn post-hiccup
-  "Given the hiccup, apply some customisation."
+  "Given the Hiccup content, applies customizations to images and code blocks:
+
+  - Add dark versions to images.
+  - Mark code blocks without any specified languages as plain text."
   [hiccup]
   (->> hiccup
        (postwalk
         (fn [h]
-          (if (and (vector? h) (= :img (first h)))
+          (cond
+            (and (vector? h) (= :img (first h)))
             (md-dark-image h)
+            (and (vector? h) (= :pre (first h)))
+            (md-code-block-default-plaintext h)
+            :else
             h)))))
 
 ;; ---------- Markdown to Hiccup ----------

--- a/client/web/src/flybot/client/web/core/dom/page/post.cljs
+++ b/client/web/src/flybot/client/web/core/dom/page/post.cljs
@@ -220,13 +220,14 @@
               (user-info editor-name last-edit-date nil :editor)])])))
 
 (defn post-view
-  [{:post/keys [css-class image-beside hiccup-content] :as post}]
+  [{:post/keys [id css-class image-beside hiccup-content] :as post}]
   (let [{:image/keys [src src-dark alt]} image-beside
         src (if (= :dark @(rf/subscribe [:subs/pattern '{:app/theme ?x}]))
               src-dark src)
         fragment-anchor [:div {:style {:height 0}}
                          [:a {:id (web.utils/post->url-identifier post)}]]
-        code-highlighting (fn [] (rf/dispatch [:evt.app/highlight-code]))
+        code-highlighting (fn [] (rf/dispatch [:evt.app/highlight-code
+                                              (str "post-" id)]))
         full-content [fragment-anchor
                       [post-authors post]
                       hiccup-content
@@ -257,7 +258,7 @@
   (when-not (utils/temporary-id? id)
     [:div.post
      {:key id
-      :id id}
+      :id (str "post-" id)}
      [post-view post]]))
 
 (defn post-read
@@ -267,7 +268,7 @@
     :as post}]
   [:div.post
    {:key id
-    :id id}
+    :id (str "post-" id)}
    [:div.post-header
     [:form
      [edit-button id]
@@ -282,7 +283,7 @@
   [{:post/keys [id]}]
   [:div.post
    {:key id
-    :id  id}
+    :id (str "post-" id)}
    [:div.post-header
     (when-not @(rf/subscribe [:subs/pattern '{:form/fields {:post/to-delete? ?x}}])
       [:form
@@ -342,7 +343,7 @@
   (let [post-title (client.utils/post->title post)]
     [:div.post.short
      {:key id
-      :id id}
+      :id (str "post-" id)}
      [post-link post
       [:div.post-body
        {:class css-class}

--- a/client/web/src/flybot/client/web/core/dom/page/post.cljs
+++ b/client/web/src/flybot/client/web/core/dom/page/post.cljs
@@ -224,10 +224,13 @@
   (let [{:image/keys [src src-dark alt]} image-beside
         src (if (= :dark @(rf/subscribe [:subs/pattern '{:app/theme ?x}]))
               src-dark src)
-        full-content [[:div {:style {:height 0}}
-                       [:a {:id (web.utils/post->url-identifier post)}]]
+        fragment-anchor [:div {:style {:height 0}}
+                         [:a {:id (web.utils/post->url-identifier post)}]]
+        code-highlighting (fn [] (rf/dispatch [:evt.app/highlight-code]))
+        full-content [fragment-anchor
                       [post-authors post]
-                      hiccup-content]]
+                      hiccup-content
+                      [code-highlighting]]]
     (if (seq src)
     ;; returns 2 hiccup divs to be displayed in 2 columns
       [:div.post-body

--- a/deps.edn
+++ b/deps.edn
@@ -36,6 +36,7 @@
   :client  {:extra-deps {com.bhauman/figwheel-main             {:mvn/version "0.2.18"}
                          org.clojure/clojurescript             {:mvn/version "1.11.60"}
                          reagent/reagent                       {:mvn/version "1.2.0"}
+                         cljsjs/highlight                      {:mvn/version "11.7.0-0"}
                          cljsjs/react                          {:mvn/version "18.2.0-1"}
                          cljsjs/react-dom                      {:mvn/version "18.2.0-1"}
                          cljsjs/react-toastify                 {:mvn/version "9.1.0-0"}

--- a/resources/public/css/highlight.css
+++ b/resources/public/css/highlight.css
@@ -1,0 +1,276 @@
+/*
+  Themes are obtained from the highlight.js repository at
+  https://github.com/highlightjs/highlight.js/tree/main/src/styles
+ */
+
+pre:has(code.hljs) {
+  display: block;
+  overflow-x: auto;
+  padding: 0.5rem 0rem;
+}
+
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1rem;
+}
+
+code.hljs {
+  padding: 3px 5px;
+}
+
+/* ------------------------------------------------------------------------- */
+
+/*!
+  Theme: GitHub
+  Description: Light theme as seen on github.com
+  Author: github.com
+  Maintainer: @Hirse
+  Updated: 2021-05-15
+
+  Outdated base version: https://github.com/primer/github-syntax-light
+  Current colors taken from GitHub's CSS
+*/
+
+.hljs {
+  color: #24292e;
+  background: #ffffff;
+}
+
+.hljs-doctag,
+.hljs-keyword,
+.hljs-meta .hljs-keyword,
+.hljs-template-tag,
+.hljs-template-variable,
+.hljs-type,
+.hljs-variable.language_ {
+  /* prettylights-syntax-keyword */
+  color: #d73a49;
+}
+
+.hljs-title,
+.hljs-title.class_,
+.hljs-title.class_.inherited__,
+.hljs-title.function_ {
+  /* prettylights-syntax-entity */
+  color: #6f42c1;
+}
+
+.hljs-attr,
+.hljs-attribute,
+.hljs-literal,
+.hljs-meta,
+.hljs-number,
+.hljs-operator,
+.hljs-variable,
+.hljs-selector-attr,
+.hljs-selector-class,
+.hljs-selector-id {
+  /* prettylights-syntax-constant */
+  color: #005cc5;
+}
+
+.hljs-regexp,
+.hljs-string,
+.hljs-meta .hljs-string {
+  /* prettylights-syntax-string */
+  color: #032f62;
+}
+
+.hljs-built_in,
+.hljs-symbol {
+  /* prettylights-syntax-variable */
+  color: #e36209;
+}
+
+.hljs-comment,
+.hljs-code,
+.hljs-formula {
+  /* prettylights-syntax-comment */
+  color: #6a737d;
+}
+
+.hljs-name,
+.hljs-quote,
+.hljs-selector-tag,
+.hljs-selector-pseudo {
+  /* prettylights-syntax-entity-tag */
+  color: #22863a;
+}
+
+.hljs-subst {
+  /* prettylights-syntax-storage-modifier-import */
+  color: #24292e;
+}
+
+.hljs-section {
+  /* prettylights-syntax-markup-heading */
+  color: #005cc5;
+  font-weight: bold;
+}
+
+.hljs-bullet {
+  /* prettylights-syntax-markup-list */
+  color: #735c0f;
+}
+
+.hljs-emphasis {
+  /* prettylights-syntax-markup-italic */
+  color: #24292e;
+  font-style: italic;
+}
+
+.hljs-strong {
+  /* prettylights-syntax-markup-bold */
+  color: #24292e;
+  font-weight: bold;
+}
+
+.hljs-addition {
+  /* prettylights-syntax-markup-inserted */
+  color: #22863a;
+  background-color: #f0fff4;
+}
+
+.hljs-deletion {
+  /* prettylights-syntax-markup-deleted */
+  color: #b31d28;
+  background-color: #ffeef0;
+}
+
+.hljs-char.escape_,
+.hljs-link,
+.hljs-params,
+.hljs-property,
+.hljs-punctuation,
+.hljs-tag {
+  /* purposely ignored */
+}
+
+/* ------------------------------------------------------------------------- */
+
+/*!
+  Theme: GitHub Dark
+  Description: Dark theme as seen on github.com
+  Author: github.com
+  Maintainer: @Hirse
+  Updated: 2021-05-15
+
+  Outdated base version: https://github.com/primer/github-syntax-dark
+  Current colors taken from GitHub's CSS
+*/
+
+.dark .hljs {
+  color: #c9d1d9;
+  background: #0d1117;
+}
+
+.dark .hljs-doctag,
+.dark .hljs-keyword,
+.dark .hljs-meta .hljs-keyword,
+.dark .hljs-template-tag,
+.dark .hljs-template-variable,
+.dark .hljs-type,
+.dark .hljs-variable.language_ {
+  /* prettylights-syntax-keyword */
+  color: #ff7b72;
+}
+
+.dark .hljs-title,
+.dark .hljs-title.class_,
+.dark .hljs-title.class_.inherited__,
+.dark .hljs-title.function_ {
+  /* prettylights-syntax-entity */
+  color: #d2a8ff;
+}
+
+.dark .hljs-attr,
+.dark .hljs-attribute,
+.dark .hljs-literal,
+.dark .hljs-meta,
+.dark .hljs-number,
+.dark .hljs-operator,
+.dark .hljs-variable,
+.dark .hljs-selector-attr,
+.dark .hljs-selector-class,
+.dark .hljs-selector-id {
+  /* prettylights-syntax-constant */
+  color: #79c0ff;
+}
+
+.dark .hljs-regexp,
+.dark .hljs-string,
+.dark .hljs-meta .hljs-string {
+  /* prettylights-syntax-string */
+  color: #a5d6ff;
+}
+
+.dark .hljs-built_in,
+.dark .hljs-symbol {
+  /* prettylights-syntax-variable */
+  color: #ffa657;
+}
+
+.dark .hljs-comment,
+.dark .hljs-code,
+.dark .hljs-formula {
+  /* prettylights-syntax-comment */
+  color: #8b949e;
+}
+
+.dark .hljs-name,
+.dark .hljs-quote,
+.dark .hljs-selector-tag,
+.dark .hljs-selector-pseudo {
+  /* prettylights-syntax-entity-tag */
+  color: #7ee787;
+}
+
+.dark .hljs-subst {
+  /* prettylights-syntax-storage-modifier-import */
+  color: #c9d1d9;
+}
+
+.dark .hljs-section {
+  /* prettylights-syntax-markup-heading */
+  color: #1f6feb;
+  font-weight: bold;
+}
+
+.dark .hljs-bullet {
+  /* prettylights-syntax-markup-list */
+  color: #f2cc60;
+}
+
+.dark .hljs-emphasis {
+  /* prettylights-syntax-markup-italic */
+  color: #c9d1d9;
+  font-style: italic;
+}
+
+.dark .hljs-strong {
+  /* prettylights-syntax-markup-bold */
+  color: #c9d1d9;
+  font-weight: bold;
+}
+
+.dark .hljs-addition {
+  /* prettylights-syntax-markup-inserted */
+  color: #aff5b4;
+  background-color: #033a16;
+}
+
+.dark .hljs-deletion {
+  /* prettylights-syntax-markup-deleted */
+  color: #ffdcd7;
+  background-color: #67060c;
+}
+
+.dark .hljs-char.escape_,
+.dark .hljs-link,
+.dark .hljs-params,
+.dark .hljs-property,
+.dark .hljs-punctuation,
+.dark .hljs-tag {
+  /* purposely ignored */
+}

--- a/resources/public/css/highlight.css
+++ b/resources/public/css/highlight.css
@@ -3,12 +3,6 @@
   https://github.com/highlightjs/highlight.js/tree/main/src/styles
  */
 
-pre:has(code.hljs) {
-  display: block;
-  overflow-x: auto;
-  padding: 0.5rem 0rem;
-}
-
 pre code.hljs {
   display: block;
   overflow-x: auto;

--- a/resources/public/css/style.css
+++ b/resources/public/css/style.css
@@ -123,7 +123,8 @@ h6 {
     color: var(--text-primary-color);
 }
 
-p {
+p,
+pre{
     padding: 0.5rem 0rem;
 }
 

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -34,7 +34,7 @@
 
         <!-- this refers to resources/public/css/style.css -->
         <link href="/css/ReactToastify.css" rel="stylesheet" type="text/css">
-        <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/default.min.css" rel="stylesheet" type="text/css">
+        <link href="/css/highlight.css" rel="stylesheet" type="text/css">
         <link href="/css/style.css" rel="stylesheet" type="text/css">
     </head>
     <body>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -34,6 +34,7 @@
 
         <!-- this refers to resources/public/css/style.css -->
         <link href="/css/ReactToastify.css" rel="stylesheet" type="text/css">
+        <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/default.min.css" rel="stylesheet" type="text/css">
         <link href="/css/style.css" rel="stylesheet" type="text/css">
     </head>
     <body>


### PR DESCRIPTION
## Closes #254

### New features

- [x] Syntax highlight code blocks in posts.
    - [x] Format code blocks without any specified languages as plain text blocks.
- [x] Add syntax highlighting themes that match the current website themes.

### Fix

- [x] Fix the HTML `<id>` attribute for posts: `<id>` should begin with a letter.[^html-id]
    This is required for the CSS selector used for syntax highlighting to work properly.

[^html-id]: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id