### PR TITLE
Handle post edits with no content changes

### DIFF
--- a/client/common/src/flybot/client/common/db/event.cljs
+++ b/client/common/src/flybot/client/common/db/event.cljs
@@ -250,10 +250,23 @@
 (rf/reg-event-fx
  :evt.post.form/send-post
  (fn [{:keys [db]} _]
-   (let [user-id (-> db :app/user :user/id)
-         post    (-> db :form/fields (valid/prepare-post user-id) (valid/validate valid/post-schema-create))]
-     (if (:errors post)
+   (let [content-keys [:post/css-class
+                       :post/md-content
+                       :post/image-beside
+                       :post/default-order]
+         user-id (-> db :app/user :user/id)
+         post    (-> db :form/fields (valid/prepare-post user-id) (valid/validate valid/post-schema-create))
+         existing-post (get-in db [:app/posts (:post/id post)])]
+     (cond
+       (:errors post)
        {:fx [[:dispatch [:evt.notif/set-notif :error/form "Form Input Error" (valid/error-msg post)]]]}
+       (= (select-keys post content-keys)
+          (select-keys existing-post content-keys))
+       {:fx [[:dispatch [:evt.notif/set-notif
+                         :warning
+                         "Post unchanged"
+                         (client.utils/post->title post)]]]}
+       :else
        {:http-xhrio (merge http-xhrio-default
                            {:headers    (when MOBILE? {:cookie (:user/cookie db)})
                             :params     {:posts

--- a/client/web/test/flybot/client/web/core/db_test.cljs
+++ b/client/web/test/flybot/client/web/core/db_test.cljs
@@ -163,6 +163,19 @@
                 (select-keys @notification [:notification/type
                                             :notification/title]))))
 
+      ;;---------- EMPTY EDIT IS IGNORED
+       (testing "Empty edit (content unchanged):"
+         (rf/dispatch [:evt.post.form/set-field
+                       :post/md-content (:post/md-content s/post-1)])
+         (rf/dispatch [:evt.post.form/send-post])
+         (testing "Warning notification sent."
+           (is (= #:notification{:type :warning
+                                 :title "Post unchanged"
+                                 :body "Some content 1"}
+                  (dissoc @notification :notification/id))))
+         (testing "Form not cleared."
+           (is @p1-form)))
+
      ;;---------- SEND POST SUCCESS
      ;; Mock success http request
      ;; Change md-content in the form

--- a/common/test/flybot/common/test_sample_data.cljc
+++ b/common/test/flybot/common/test_sample_data.cljc
@@ -11,7 +11,8 @@
    #inst "2023-01-04"
    #inst "2023-01-05"
    #inst "2023-01-06"
-   #inst "2023-01-07"])
+   #inst "2023-01-07"
+   #inst "2023-01-08"])
 
 ;;---------- Users ----------
 
@@ -59,6 +60,7 @@
 (def post-1-edit-date (nth dates 4))
 (def post-2-create-date (nth dates 5))
 (def post-3-create-date (nth dates 6))
+(def post-3-edit-date (nth dates 7))
 
 (def post-1
   #:post{:id             post-1-id

--- a/server/test/flybot/server/core/handler/operation_test.clj
+++ b/server/test/flybot/server/core/handler/operation_test.clj
@@ -33,8 +33,10 @@
                                [(assoc post-in :post/default-order 2)]}}}
                (sut/add-post (d/db db-conn) post-in)))))
     (testing "User is admin and edits post of other so returns new post."
-      (let [post-in s/post-1
+      (let [post-in (assoc s/post-1
+                           :post/md-content "# Edited content 1")
             post-out (assoc s/post-1
+                            :post/md-content "# Edited content 1"
                             :post/author s/alice-user
                             :post/last-editor s/bob-user)]
         (is (= {:response post-out

--- a/server/test/flybot/server/core/handler_test.clj
+++ b/server/test/flybot/server/core/handler_test.clj
@@ -270,12 +270,7 @@
                                                :user/roles [{:role/name '?
                                                              :role/date-granted '?}]}
                                  :post/creation-date '?
-                                 :post/last-editor {:user/id '?
-                                                    :user/email '?
-                                                    :user/name '?
-                                                    :user/picture '?
-                                                    :user/roles [{:role/name '?
-                                                                  :role/date-granted '?}]}
+                                 :post/last-editor {:user/id '?}
                                  :post/last-edit-date '?
                                  :post/md-content '?
                                  :post/default-order '?}}})
@@ -284,12 +279,7 @@
                               {:posts
                                {(list :post :with [s/post-3-id])
                                 {:post/id '?
-                                 :post/last-editor {:user/id '?
-                                                    :user/email '?
-                                                    :user/name '?
-                                                    :user/picture '?
-                                                    :user/roles [{:role/name '?
-                                                                  :role/date-granted '?}]}
+                                 :post/last-editor {:user/id '?}
                                  :post/last-edit-date '?}}})]
             (testing "Response is the existing post."
               (is (= post-out


### PR DESCRIPTION
## Closes #256

### New behavior

- On the front end, when the user attempts to submit a post edit without changing any content first:
    - [x] Send a warning notification.
    - [x] Keep the post in edit mode.

- On the back end, when receiving a post submission with the same content as the existing post
    - [x] Include the existing post in the HTTP response.
    - [x] Do not update the database (e.g., do not change the post's `:post/last-edit-date`).

### Note

Post content consists of `:post/page`, `:post/md-content`, `:post/css-class`, `:post/image-beside` and `:post/default-order`.