### PR TITLE
Allow owner to add back editor from UI

### DIFF
--- a/client/web/src/flybot/client/web/core/dom/page/admin.cljs
+++ b/client/web/src/flybot/client/web/core/dom/page/admin.cljs
@@ -86,6 +86,10 @@
        [grant-role-form :admin]]
       [:div
        [:form
+        [grant-role-button :editor]]
+       [grant-role-form :editor]]
+      [:div
+       [:form
         [revoke-role-button :admin]]
        [revoke-role-form :admin]]]
      [:div

--- a/common/src/flybot/common/validation.cljc
+++ b/common/src/flybot/common/validation.cljc
@@ -111,6 +111,7 @@
               [:registered [:=> [:cat :string user-email-schema :string :string] user-schema]]
               [:logged [:=> [:cat] user-schema]]]]
       [:new-role [:map
+                  [:editor [:=> [:cat user-email-schema] user-schema]]
                   [:admin [:=> [:cat user-email-schema] user-schema]]
                   [:owner [:=> [:cat user-email-schema] user-schema]]]]
       [:revoked-role [:map
@@ -134,6 +135,7 @@
    '?src "Image for Light Mode"
    '?src-dark "Image for Dark Mode"
    '?alt "Image Description"
+   '?new-editor "Grant Editor Role"
    '?new-admin "Grant Admin Role"
    '?new-owner "Grant Owner Role"
    '?revoked-admin "Revoke Admin Role"})
@@ -149,8 +151,9 @@
                      :post/image-beside {:image/src ?src
                                          :image/src-dark ?src-dark
                                          :image/alt ?alt}
-                     :new-role {:admin {:user/email ?new-admin}
-                                :owner {:user/email ?new-owner}}
+                     :new-role {:editor {:user/email ?new-editor}
+                                :admin  {:user/email ?new-admin}
+                                :owner  {:user/email ?new-owner}}
                      :revoked-role {:admin {:user/email ?revoked-admin}}}))
       (dissoc '&?)
       (#(into {} (remove (comp nil? val) %)))

--- a/common/test/flybot/common/test_sample_data.cljc
+++ b/common/test/flybot/common/test_sample_data.cljc
@@ -12,7 +12,8 @@
    #inst "2023-01-05"
    #inst "2023-01-06"
    #inst "2023-01-07"
-   #inst "2023-01-08"])
+   #inst "2023-01-08"
+   #inst "2023-01-09"])
 
 ;;---------- Users ----------
 
@@ -22,6 +23,7 @@
 (def bob-date-granted (nth dates 0))
 (def alice-date-granted (nth dates 1))
 (def joshua-date-granted (nth dates 2))
+(def charlie-date-granted (nth dates 8))
 
 (def bob-user
   #:user{:id "bob-id"
@@ -48,6 +50,12 @@
          :picture "joshua-pic"
          :roles [#:role{:name :editor
                         :date-granted joshua-date-granted}]})
+
+(def charlie-user
+  #:user{:id "charlie-id"
+         :email "charlie@basecity.com"
+         :name "Charlie"
+         :picture "charlie-pic"})
 
 ;;---------- Posts ----------
 

--- a/server/src/flybot/server/core/handler/operation.clj
+++ b/server/src/flybot/server/core/handler/operation.clj
@@ -125,12 +125,12 @@
 
 (defn- grant-role
   [db email role-to-have role-to-grant]
-  (let [{:user/keys [roles] :as user} (db/get-user-by-email db email)]
+  (let [{:user/keys [roles] :as user :or {roles []}} (db/get-user-by-email db email)]
     (cond (not user)
           {:error {:type           :user/not-found
                    :user-email     email}}
           
-          (not (some #{role-to-have} (map :role/name roles)))
+          (and role-to-have (not (some #{role-to-have} (map :role/name roles))))
           {:error {:type           :user/missing-role
                    :missing-role   role-to-have
                    :requested-role role-to-grant
@@ -143,8 +143,13 @@
           
           :else
           (let [new-role {:role/name role-to-grant :role/date-granted (utils/mk-date)}]
-            {:response (update user :user/roles conj new-role)
+            {:response (-> user
+                           (update :user/roles vec)
+                           (update  :user/roles conj new-role))
              :effects  {:db {:payload [(assoc user :user/roles [new-role])]}}}))))
+
+(def grant-editor-role
+  #(grant-role %1 %2 nil :editor))
 
 (def grant-admin-role
   #(grant-role %1 %2 :editor :admin))
@@ -194,9 +199,11 @@
                            (fn [id] (delete-user db id)))
            :auth         {:registered (fn [id email name picture] (register-user db id email name picture))
                           :logged     (fn [] (login-user db (:user-id session)))}
-           :new-role     {:admin (with-role session :owner
-                                   (fn [email] (grant-admin-role db email)))
-                          :owner (with-role session :owner
-                                   (fn [email] (grant-owner-role db email)))}
+           :new-role     {:editor (with-role session :owner
+                                    (fn [email] (grant-editor-role db email)))
+                          :admin  (with-role session :owner
+                                    (fn [email] (grant-admin-role db email)))
+                          :owner  (with-role session :owner
+                                    (fn [email] (grant-owner-role db email)))}
            :revoked-role {:admin (with-role session :owner
                                    (fn [email] (revoke-admin-role db email)))}}})

--- a/server/src/flybot/server/core/handler/operation.clj
+++ b/server/src/flybot/server/core/handler/operation.clj
@@ -143,9 +143,7 @@
           
           :else
           (let [new-role {:role/name role-to-grant :role/date-granted (utils/mk-date)}]
-            {:response (-> user
-                           (update :user/roles vec)
-                           (update  :user/roles conj new-role))
+            {:response (update user :user/roles #(-> % vec (conj new-role)))
              :effects  {:db {:payload [(assoc user :user/roles [new-role])]}}}))))
 
 (def grant-editor-role

--- a/server/src/flybot/server/systems/init_data.clj
+++ b/server/src/flybot/server/systems/init_data.clj
@@ -31,9 +31,7 @@
   "Alice is editor"
   #:user{:id "alice-id"
          :email "alice@basecity.com"
-         :name "Alice Martin"
-         :roles [#:role{:name :editor
-                        :date-granted (u/mk-date)}]})
+         :name "Alice Martin"})
 
 (def users
   [owner-user bob-user alice-user])

--- a/server/src/flybot/server/systems/init_data.clj
+++ b/server/src/flybot/server/systems/init_data.clj
@@ -31,7 +31,9 @@
   "Alice is editor"
   #:user{:id "alice-id"
          :email "alice@basecity.com"
-         :name "Alice Martin"})
+         :name "Alice Martin"
+         :roles [#:role{:name :editor
+                        :date-granted (u/mk-date)}]})
 
 (def users
   [owner-user bob-user alice-user])

--- a/server/test/flybot/server/core/handler/operation_test.clj
+++ b/server/test/flybot/server/core/handler/operation_test.clj
@@ -147,10 +147,10 @@
                         :role    :admin
                         :user-email admin-email}}
                (sut/grant-admin-role (d/db db-conn) admin-email)))))
-    (testing "Editor role case where not previous role is required."
+    (testing "Editor role case where no previous role is required."
       (with-redefs [utils/mk-date (constantly s/charlie-date-granted)]
         (let [new-role {:role/name :editor :role/date-granted s/charlie-date-granted}
-              updated-charlie (update s/charlie-user :user/roles conj new-role)
+              updated-charlie (assoc s/charlie-user :user/roles [new-role])
               effects (assoc s/charlie-user :user/roles [new-role])]
           (is (= {:response updated-charlie
                   :effects  {:db {:payload [effects]}}}


### PR DESCRIPTION
Closes #262
---

- add the backend logic to add back the `:editor` role to an existing user
- add the UI admin form to give back `:editor` role to an existing user