### PR TITLE
Fix cljs headless tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,9 +27,8 @@ jobs:
       - name: Run the clj tests
         run: clojure -A:jvm-base:server/test
 
-      ## Not working as for now, refer to tests.cljs.edn
-      #- name: Run the cljs tests
-      #  run: clojure -A:jvm-base:client:web/test-headless
+      - name: Run the cljs tests
+        run: clojure -A:jvm-base:client:web/test-headless
 
       - name: Build main.js
         run: clojure -T:build js-bundle

--- a/tests.cljs.edn
+++ b/tests.cljs.edn
@@ -2,8 +2,8 @@
 ^{:launch-js
   ;; mac
   #_["/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
-   "--headless" "--remote-debugging-port=9222" :open-url]
+   "--headless" "--disable-gpu" "--disable-dev-shm" "--remote-debugging-port=9222" :open-url]
   ;; ubuntu
   ["/opt/google/chrome/chrome"
-   "--headless" "--remote-debugging-port=9222" :open-url]}
+   "--headless" "--disable-gpu" "--disable-dev-shm" "--remote-debugging-port=9222" :open-url]}
 {:main flybot.client.web.test-runner}

--- a/tests.cljs.edn
+++ b/tests.cljs.edn
@@ -2,10 +2,10 @@
 ^{:launch-js
   ;; mac
   #_["/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
-   "--headless" "--disable-gpu" "--repl" "--disable-dev-shm" "--dump-dom" :open-url]
+   "--headless" "--remote-debugging-port=9222" :open-url]
   ;; ubuntu
   ["/opt/google/chrome/chrome"
-   "--headless" "--disable-gpu" "--repl" "--disable-dev-shm" :open-url]}
+   "--headless" "--remote-debugging-port=9222" :open-url]}
 {:main flybot.client.web.test-runner}
 
 ;; ::TOFIX

--- a/tests.cljs.edn
+++ b/tests.cljs.edn
@@ -7,8 +7,3 @@
   ["/opt/google/chrome/chrome"
    "--headless" "--remote-debugging-port=9222" :open-url]}
 {:main flybot.client.web.test-runner}
-
-;; ::TOFIX
-;; Terminal hangs at:
-;; Launching Javascript environment with script:  ["/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" "--headless" "--disable-gpu" "--repl" "--disable-dev-shm" "--dump-dom" :open-url]
-;; Environment output being logged to: target/public/cljs-out/tests/js-environment.log


### PR DESCRIPTION
Closes #156 
---

On the clojurians slack, I saw a [message](https://clojurians.slack.com/archives/CALJ3BFLP/p1691413381264179?thread_ts=1691403762.060289&cid=CALJ3BFLP) suggesting to use `--remote-debugging-port=9222` and it solved the issue for both mac and linux.